### PR TITLE
Fixed capability type

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,8 +1,8 @@
 import { Requester } from "./common"
-import { CellId, AgentPubKey, AppId, InstalledCell, InstalledApp } from "./types"
+import { CellId, CapSecret, AgentPubKey, AppId, InstalledApp } from "./types"
 
 export type CallZomeRequestGeneric<Payload> = {
-  cap: Buffer,
+  cap: CapSecret,
   cell_id: CellId,
   zome_name: string,
   fn_name: string,

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -2,7 +2,7 @@ import { Requester } from "./common"
 import { CellId, AgentPubKey, AppId, InstalledCell, InstalledApp } from "./types"
 
 export type CallZomeRequestGeneric<Payload> = {
-  cap: string,
+  cap: Buffer,
   cell_id: CellId,
   zome_name: string,
   fn_name: string,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -5,6 +5,7 @@ export type AgentPubKey = {
   hash_type: Buffer,
 }
 export type AppId = string
+export type CapSecret = Buffer
 export type CellId = [Hash, AgentPubKey]
 export type CellNick = string
 export type DnaProperties = any

--- a/src/websocket/app.ts
+++ b/src/websocket/app.ts
@@ -48,12 +48,7 @@ export class AppWebsocket implements AppApi {
 
 const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Buffer>, CallZomeResponseGeneric<Buffer>, CallZomeResponseGeneric<any>> = {
   input: (req: CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Buffer> => {
-    // FIXME: the Buffer produced by msgpack.encode must be converted to an Array of numbers,
-    // because on the Holochain side, SerializedBytes only knows how to deserialize from an array.
-    // Once SerializedBytes and other structs are ported to use serde_bytes, then the following line
-    // can be rewritten as:
-    // req.payload = msgpack.encode(req.payload)
-    req.payload = [...msgpack.encode(req.payload)]
+    req.payload = msgpack.encode(req.payload)
     return req
   },
   output: (res: CallZomeResponseGeneric<Buffer>): CallZomeResponseGeneric<any> => {

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -57,7 +57,7 @@ test('can call a zome function', withConductor(ADMIN_PORT, async t => {
   t.equal(info.cell_data[0][1], 'mydna')
 
   const response = await client.callZome({
-    cap: 'secret',
+    cap: Buffer.from(Array(64).fill('aa').join(''), 'hex'), // TODO: change to a real capability secret
     cell_id: cellId,
     zome_name: 'foo',
     fn_name: 'foo',


### PR DESCRIPTION
As new the new holochain conductor interface now checks for the type and length of the capability secret, but not its contents, the holochain-conductor-api types for that parameter in the `callZome` function should align to that. Otherwise, right now a consumer of either this library or tryorama has to hack their `node_modules` folder for the `callZomes` to work.

Any suggestions better than `Buffer` are welcomed, this is more of a temporary fix until good capabilities are implemented.

See also https://github.com/Holo-Host/tryorama-rsm/pull/2.