### PR TITLE
add pre-existing listCellIds admin method

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@holochain/conductor-api",
   "version": "0.0.1-dev.8",
   "description": "Encode/decode messages to/from the Holochain Conductor API over Websocket",
-  "repository" : { 
-    "type" : "git",
-    "url" : "https://github.com/holochain/holochain-conductor-api.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holochain/holochain-conductor-api.git"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -26,6 +26,9 @@ export type InstallAppResponse = InstalledApp
 export type ListDnasRequest = void
 export type ListDnasResponse = Array<string>
 
+export type ListCellIdsRequest = void
+export type ListCellIdsResponse = Array<CellId>
+
 export interface AdminApi {
   activateApp: Requester<ActivateAppRequest, ActivateAppResponse>
   attachAppInterface: Requester<AttachAppInterfaceRequest, AttachAppInterfaceResponse>
@@ -34,6 +37,7 @@ export interface AdminApi {
   generateAgentPubKey: Requester<GenerateAgentPubKeyRequest, GenerateAgentPubKeyResponse>
   installApp: Requester<InstallAppRequest, InstallAppResponse>
   listDnas: Requester<ListDnasRequest, ListDnasResponse>
+  listCellIds: Requester<ListCellIdsRequest, ListCellIdsResponse>
 }
 
 

--- a/src/websocket/admin.ts
+++ b/src/websocket/admin.ts
@@ -56,6 +56,8 @@ export class AdminWebsocket implements Api.AdminApi {
     = this._requester('InstallApp')
   listDnas: Requester<Api.ListDnasRequest, Api.ListDnasResponse>
     = this._requester('ListDnas')
+  listCellIds: Requester<Api.ListCellIdsRequest, Api.ListCellIdsResponse>
+    = this._requester('ListCellIds')
 }
 
 


### PR DESCRIPTION
I was looking in to the admin API in core to see about adding a listApps method, when I discovered that there is already a `listCellIds` method, it just wasn't here in the `holochain-conductor-api` repo yet. 

I think I might still look into `listApps` because it would seem to have its own utility slightly distinct from this, but for now, this.

Reference:
https://github.com/holochain/holochain/blob/eff0ca04dc1be6c6b549ef186fcece9f28cd76f8/crates/holochain/src/conductor/api/api_external/admin_interface.rs#L130-L133