### PR TITLE
Update for HoloHash serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=96815c179373bbc1ffca84c48e97c5a7746e4ead#96815c179373bbc1ffca84c48e97c5a7746e4ead"
+source = "git+https://github.com/holochain/holochain?rev=beaab9949fbff121ffd138f36c4e61c5693b8fd6#beaab9949fbff121ffd138f36c4e61c5693b8fd6"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -104,7 +104,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=96815c179373bbc1ffca84c48e97c5a7746e4ead#96815c179373bbc1ffca84c48e97c5a7746e4ead"
+source = "git+https://github.com/holochain/holochain?rev=beaab9949fbff121ffd138f36c4e61c5693b8fd6#beaab9949fbff121ffd138f36c4e61c5693b8fd6"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=96815c179373bbc1ffca84c48e97c5a7746e4ead#96815c179373bbc1ffca84c48e97c5a7746e4ead"
+source = "git+https://github.com/holochain/holochain?rev=beaab9949fbff121ffd138f36c4e61c5693b8fd6#beaab9949fbff121ffd138f36c4e61c5693b8fd6"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=96815c179373bbc1ffca84c48e97c5a7746e4ead#96815c179373bbc1ffca84c48e97c5a7746e4ead"
+source = "git+https://github.com/holochain/holochain?rev=beaab9949fbff121ffd138f36c4e61c5693b8fd6#beaab9949fbff121ffd138f36c4e61c5693b8fd6"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.46"
+version = "0.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee46b8c29e3823cd71f62d6be4f524943f3ee4e8df25f2e758b5feb576636d2"
+checksum = "d4c7be01e9d8b4e42529fcb2b4f5f550cb57430675573c303b52466757be1df0"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.46"
+version = "0.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25baad68477da31c444f4c036f8c9da5c129024aa23041e6d3c2fa42c3cdff4"
+checksum = "08272448369148affd94fbb19a58e4a06bd6e9e171d587d656439a387d918d6d"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=96815c179373bbc1ffca84c48e97c5a7746e4ead#96815c179373bbc1ffca84c48e97c5a7746e4ead"
+source = "git+https://github.com/holochain/holochain?rev=beaab9949fbff121ffd138f36c4e61c5693b8fd6#beaab9949fbff121ffd138f36c4e61c5693b8fd6"
 dependencies = [
  "fixt",
  "holo_hash",

--- a/README.md
+++ b/README.md
@@ -22,18 +22,17 @@ npm install --save-exact @holochain/conductor-api
 
 This version of `holochain-conductor-api` is currently working with `holochain/holochain` at commit:
 
-[96815c179373bbc1ffca84c48e97c5a7746e4ead](https://github.com/holochain/holochain/commit/96815c179373bbc1ffca84c48e97c5a7746e4ead) (October 27, 2020)
+[beaab9949fbff121ffd138f36c4e61c5693b8fd6](https://github.com/holochain/holochain/commit/beaab9949fbff121ffd138f36c4e61c5693b8fd6) (Nov 10, 2020)
 
 If updating this code, please make changes to the git `rev/sha` in 3 places:
 1. Here in the README above ^^
-2. These lines in `install-holochain.sh`
-```
-cargo install --force holochain --git https://github.com/holochain/holochain.git --rev 96815c179373bbc1ffca84c48e97c5a7746e4ead
-cargo install --force dna_util --git https://github.com/holochain/holochain.git --rev 96815c179373bbc1ffca84c48e97c5a7746e4ead
+2. This line in `install-holochain.sh`
+```bash
+REV=beaab9949fbff121ffd138f36c4e61c5693b8fd6
 ```
 3. and this line in `test/e2e/fixtures/zomes/foo/Cargo.toml`
 ```
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "96815c179373bbc1ffca84c48e97c5a7746e4ead", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "beaab9949fbff121ffd138f36c4e61c5693b8fd6", package = "hdk3" }
 ```
 
 Notice the match between the SHA in both cases. These should always match.

--- a/install-holochain.sh
+++ b/install-holochain.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-cargo install --force holochain --git https://github.com/holochain/holochain.git --rev 96815c179373bbc1ffca84c48e97c5a7746e4ead
-cargo install --force dna_util --git https://github.com/holochain/holochain.git --rev 96815c179373bbc1ffca84c48e97c5a7746e4ead
+REV=beaab9949fbff121ffd138f36c4e61c5693b8fd6
+
+cargo install --force holochain \
+  --git https://github.com/holochain/holochain.git \
+  --rev $REV
+cargo install --force dna_util \
+  --git https://github.com/holochain/holochain.git \
+  --rev $REV

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
     "test": "npm run test:raw | tap-diff",
-    "test:raw": "RUST_LOG=error RUST_BACKTRACE=1 ts-node test",
+    "test:raw": "P2P_BOOTSTRAP_URL=\"\" RUST_LOG=error RUST_BACKTRACE=1 ts-node test",
     "example": "ts-node examples/zome-call"
   },
   "author": "",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,8 +1,8 @@
-export type Hash = Buffer // length 39
-export type AgentPubKey = Hash
+export type HoloHash = Buffer // length 39
+export type AgentPubKey = HoloHash
 export type AppId = string
 export type CapSecret = Buffer
-export type CellId = [Hash, AgentPubKey]
+export type CellId = [HoloHash, AgentPubKey]
 export type CellNick = string
 export type DnaProperties = any
 export type InstalledApp = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,26 +1,22 @@
-
-// TODO: update when HoloHash structure becomes simple byte array
-export type AgentPubKey = {
-  hash: Buffer,
-  hash_type: Buffer,
-}
-export type Hash = {
-  hash: Buffer,
-  hash_type: Buffer,
-}
+export type Hash = Buffer // length 39
+export type AgentPubKey = Hash
 export type AppId = string
 export type CapSecret = Buffer
 export type CellId = [Hash, AgentPubKey]
 export type CellNick = string
 export type DnaProperties = any
 export type InstalledApp = {
-  app_id: AppId,
-  cell_data: Array<InstalledCell>,
+  app_id: AppId
+  cell_data: Array<InstalledCell>
 }
 export type InstalledCell = [CellId, CellNick]
 export type MembraneProof = Buffer
 
-export const fakeAgentPubKey = (x: any) => ({
-  hash: Buffer.from("000000000000000000000000000000000000".split('').map(x => parseInt(x, 10))),
-  hash_type: Buffer.from([0x84, 0x20, 0x24])
-})
+export const fakeAgentPubKey = (x: any) =>
+  Buffer.from(
+    [0x84, 0x20, 0x24].concat(
+      '000000000000000000000000000000000000'
+        .split('')
+        .map((x) => parseInt(x, 10))
+    )
+  )

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.104"
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "96815c179373bbc1ffca84c48e97c5a7746e4ead", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "beaab9949fbff121ffd138f36c4e61c5693b8fd6", package = "hdk3" }

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -84,6 +84,7 @@ export const installAppAndDna = async (
   const nick = 'mydna'
   const admin = await AdminWebsocket.connect(`http://localhost:${adminPort}`)
   const agent = await admin.generateAgentPubKey()
+  console.log('AGENT!', agent)
   const app = await admin.installApp({
     app_id,
     agent_key: agent,
@@ -94,6 +95,7 @@ export const installAppAndDna = async (
       },
     ],
   })
+  console.log('APP!', app)
   const cell_id = app.cell_data[0][0]
   await admin.activateApp({ app_id })
   // destructure to get whatever open port was assigned to the interface

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -84,7 +84,6 @@ export const installAppAndDna = async (
   const nick = 'mydna'
   const admin = await AdminWebsocket.connect(`http://localhost:${adminPort}`)
   const agent = await admin.generateAgentPubKey()
-  console.log('AGENT!', agent)
   const app = await admin.installApp({
     app_id,
     agent_key: agent,
@@ -95,7 +94,6 @@ export const installAppAndDna = async (
       },
     ],
   })
-  console.log('APP!', app)
   const cell_id = app.cell_data[0][0]
   await admin.activateApp({ app_id })
   // destructure to get whatever open port was assigned to the interface


### PR DESCRIPTION
- [x] change `Hash` to `HoloHash` and make it a simple Buffer, instead of an object/struct
- [x] add P2P_BOOTSTRAP_URL="" necessary to prevent fatal errors
- [x] update holochain version to https://github.com/holochain/holochain/commit/beaab9949fbff121ffd138f36c4e61c5693b8fd6