### PR TITLE
Socket open onError fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/conductor-api",
-  "version": "0.0.1-dev.11",
+  "version": "0.0.1-dev.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -62,7 +62,7 @@ export class WsClient {
       // with uncaught exception
       socket.onerror = (e) => {
         reject(new Error(
-          `error while connecting to holochain at ${url}: ${e.error.name}, ${e.error.message}`
+          `could not connect to holochain conductor, please check that a conductor service is running and available at ${url}`
         ))
       }
       socket.onopen = () => {

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -61,16 +61,9 @@ export class WsClient {
       // errors because that causes nodejs thread to crash
       // with uncaught exception
       socket.onerror = (e) => {
-        console.log("Socket err", e.data)
-        if (e.error.code === 'ECONNRESET' || e.error.code === 'ECONNREFUSED') {
-          reject(
-            new Error(
-              `could not connect to holochain conductor, please check that a conductor service is running and available at ${url}`
-            )
-          )
-        } else {
-          reject(e)
-        }
+        reject(new Error(
+          `could not connect to holochain conductor, please check that a conductor service is running and available at ${url}`
+        ))
       }
       socket.onopen = () => {
         const hw = new WsClient(socket)

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -61,7 +61,7 @@ export class WsClient {
       // errors because that causes nodejs thread to crash
       // with uncaught exception
       socket.onerror = (e) => {
-        console.log("Socket err", e)
+        console.log("Socket err", e.data)
         if (e.error.code === 'ECONNRESET' || e.error.code === 'ECONNREFUSED') {
           reject(
             new Error(

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -62,7 +62,7 @@ export class WsClient {
       // with uncaught exception
       socket.onerror = (e) => {
         reject(new Error(
-          `could not connect to holochain conductor, please check that a conductor service is running and available at ${url}`
+          `error while connecting to holochain at ${url}: ${e.error.name}, ${e.error.message}`
         ))
       }
       socket.onopen = () => {

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -20,11 +20,11 @@ export class WsClient {
   }
 
   emitSignal(data: any) {
-    const encoded = msgpack.encode({
+    const encodedMsg = msgpack.encode({
       type: 'Signal',
       data: msgpack.encode(data),
     })
-    this.socket.send(encoded)
+    this.socket.send(encodedMsg)
   }
 
   request<Req, Res>(data: Req): Promise<Res> {
@@ -61,6 +61,7 @@ export class WsClient {
       // errors because that causes nodejs thread to crash
       // with uncaught exception
       socket.onerror = (e) => {
+        console.log("Socket err", e)
         if (e.error.code === 'ECONNRESET' || e.error.code === 'ECONNREFUSED') {
           reject(
             new Error(

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -37,7 +37,11 @@ export class WsClient {
     const promise = new Promise((fulfill) => {
       this.pendingRequests[id] = { fulfill }
     })
-    this.socket.send(encodedMsg)
+    if (this.socket.readyState === this.socket.OPEN) {
+      this.socket.send(encodedMsg)
+    } else {
+      return Promise.reject(new Error(`Socket is not open`))
+    }
     return promise as Promise<Res>
   }
 


### PR DESCRIPTION
- [x] Websocket error results (on browser) do not actually return the error code.  
- [x] calling send on a closed websocket was causing promises never returned errors.