### PR TITLE
bug fix for use in ts UI

### DIFF
--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -1,4 +1,4 @@
-import Websocket from 'isomorphic-ws'
+import * as Websocket from 'isomorphic-ws'
 import * as msgpack from '@msgpack/msgpack'
 import { nanoid } from 'nanoid'
 import { AppSignal, AppSignalCb, SignalResponseGeneric } from '../api/app'


### PR DESCRIPTION
Hi All,

I pulled this pkg into a UI that was built in typescript and it was not able to build this pkg.

This is the error it was throwing 
```
"isomorphic-ws/index"' has no default export
```

This small change fixes the issue.