### PR TITLE
Add support for register-dna

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
+source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -110,7 +110,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
+source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
+source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
+source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
+source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
 dependencies = [
  "fixt",
  "holo_hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
+source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -110,7 +110,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
+source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
+source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
+source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=c1286bc8f41c3de5fc5823bf0ccf8869df92c548#c1286bc8f41c3de5fc5823bf0ccf8869df92c548"
+source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
 dependencies = [
  "fixt",
  "holo_hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -110,7 +110,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=d770a2e71df9d4cc87c91b926322be71a0785396#d770a2e71df9d4cc87c91b926322be71a0785396"
+source = "git+https://github.com/holochain/holochain?rev=ea026def01d1573d5e0edfb7f4e3e9453f88c43e#ea026def01d1573d5e0edfb7f4e3e9453f88c43e"
 dependencies = [
  "fixt",
  "holo_hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,15 +43,21 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cloudabi"
@@ -71,7 +77,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "fixt"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7#3675b588de0aaf7eb9dc852b4012f3cfa5a27df7"
+source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -86,11 +92,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -104,7 +110,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 [[package]]
 name = "hdk3"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7#3675b588de0aaf7eb9dc852b4012f3cfa5a27df7"
+source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
 dependencies = [
  "hdk3_derive",
  "holo_hash",
@@ -119,13 +125,13 @@ dependencies = [
 [[package]]
 name = "hdk3_derive"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7#3675b588de0aaf7eb9dc852b4012f3cfa5a27df7"
+source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
 dependencies = [
  "holochain_zome_types",
  "paste",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.55",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -140,7 +146,7 @@ dependencies = [
 [[package]]
 name = "holo_hash"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7#3675b588de0aaf7eb9dc852b4012f3cfa5a27df7"
+source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -153,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.46"
+version = "0.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8fe6bc8c830633862ee0b7903706f6d940f7c794b3f5e768f660a7abbacbc9"
+checksum = "80e1f2f82c9ac6dc7bc7c2e06e892d4bd1f29b4681cbfa4886edeb25ee8cdfe3"
 dependencies = [
  "holochain_serialized_bytes_derive",
  "rmp-serde",
@@ -168,19 +174,19 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.46"
+version = "0.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a4c0ef882177ac63c8912ae9c1eb6285d3b50a56f2bb0cebc41012255b7734"
+checksum = "0119b7cd2aa14e4bc7129a212ff570bcba295ae19392067b2b0deeba780729e9"
 dependencies = [
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.52"
+version = "0.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e064411f7c8cf58e08a451c2df9ab99efb5de839f74a650c1a30abbd607add8"
+checksum = "bf8aef6d62ba25d471c48161c1fe0e79b5196bb57f6e33a28dd584b585013050"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -189,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.52"
+version = "0.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c86bf521e02f8f86ea96177ef316560e66e51a192b83a302e8e4b32a6f47f02"
+checksum = "fc8f04f75daaa56db47e940161b94052c6b858140673216302383224751fd500"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -201,12 +207,13 @@ dependencies = [
 [[package]]
 name = "holochain_zome_types"
 version = "0.0.1"
-source = "git+https://github.com/holochain/holochain?rev=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7#3675b588de0aaf7eb9dc852b4012f3cfa5a27df7"
+source = "git+https://github.com/holochain/holochain?rev=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0#3af5e8d6c1d7a167db808af9f2de7003a5d7bff0"
 dependencies = [
  "fixt",
  "holo_hash",
  "holochain_serialized_bytes",
  "paste",
+ "rand",
  "serde",
  "serde_bytes",
  "strum",
@@ -226,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lazy_static"
@@ -238,9 +245,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "lock_api"
@@ -276,7 +283,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "libc",
  "redox_syscall",
@@ -298,29 +305,11 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -329,7 +318,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -445,16 +434,16 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.55",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "indexmap",
  "itoa",
@@ -464,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strum"
@@ -481,9 +470,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.55",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -494,24 +483,13 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -524,22 +502,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.55",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -547,12 +525,6 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ npm install --save-exact @holochain/conductor-api
 
 This version of `holochain-conductor-api` is currently working with `holochain/holochain` at commit:
 
-[3675b588de0aaf7eb9dc852b4012f3cfa5a27df7](https://github.com/holochain/holochain/commit/3675b588de0aaf7eb9dc852b4012f3cfa5a27df7) (Dec 21, 2020)
+[3af5e8d6c1d7a167db808af9f2de7003a5d7bff0](https://github.com/holochain/holochain/commit/3af5e8d6c1d7a167db808af9f2de7003a5d7bff0) (Jan 9, 2021)
 
 If updating this code, please make changes to the git `rev/sha` in 3 places:
 1. Here in the README above ^^
 2. This line in `install-holochain.sh`
 ```bash
-REV=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7
+REV=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0
 ```
 3. and this line in `test/e2e/fixtures/zomes/foo/Cargo.toml`
 ```
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "3675b588de0aaf7eb9dc852b4012f3cfa5a27df7", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "3af5e8d6c1d7a167db808af9f2de7003a5d7bff0", package = "hdk3" }
 ```
 
 Notice the match between the SHA in both cases. These should always match.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ License: [![License: CAL 1.0](https://img.shields.io/badge/License-CAL%201.0-blu
 
 A nodejs implementation of the Holochain conductor API.
 
+# Conductor API documentation
+
+Holochain's conductor API is under active development.  This node module tracks that development fairly closely but sometimes gets behind.
+
 # Install
 
 To install from NPM, run
@@ -52,17 +56,17 @@ npm install --save-exact @holochain/conductor-api
 
 This version of `holochain-conductor-api` is currently working with `holochain/holochain` at commit:
 
-[c1286bc8f41c3de5fc5823bf0ccf8869df92c548](https://github.com/holochain/holochain/commit/c1286bc8f41c3de5fc5823bf0ccf8869df92c548) (Jan 11, 2021)
+[d770a2e71df9d4cc87c91b926322be71a0785396](https://github.com/holochain/holochain/commit/d770a2e71df9d4cc87c91b926322be71a0785396) (Jan 11, 2021)
 
 If updating this code, please make changes to the git `rev/sha` in 3 places:
 1. Here in the README above ^^
 2. This line in `install-holochain.sh`
 ```bash
-REV=c1286bc8f41c3de5fc5823bf0ccf8869df92c548
+REV=d770a2e71df9d4cc87c91b926322be71a0785396
 ```
 3. and this line in `test/e2e/fixtures/zomes/foo/Cargo.toml`
 ```
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "c1286bc8f41c3de5fc5823bf0ccf8869df92c548", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "d770a2e71df9d4cc87c91b926322be71a0785396", package = "hdk3" }
 ```
 
 Notice the match between the SHA in both cases. These should always match.

--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ npm install --save-exact @holochain/conductor-api
 
 This version of `holochain-conductor-api` is currently working with `holochain/holochain` at commit:
 
-[d770a2e71df9d4cc87c91b926322be71a0785396](https://github.com/holochain/holochain/commit/d770a2e71df9d4cc87c91b926322be71a0785396) (Jan 11, 2021)
+[ea026def01d1573d5e0edfb7f4e3e9453f88c43e](https://github.com/holochain/holochain/commit/ea026def01d1573d5e0edfb7f4e3e9453f88c43e) (Jan 14, 2021)
 
 If updating this code, please make changes to the git `rev/sha` in 3 places:
 1. Here in the README above ^^
 2. This line in `install-holochain.sh`
 ```bash
-REV=d770a2e71df9d4cc87c91b926322be71a0785396
+REV=ea026def01d1573d5e0edfb7f4e3e9453f88c43e
 ```
 3. and this line in `test/e2e/fixtures/zomes/foo/Cargo.toml`
 ```
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "d770a2e71df9d4cc87c91b926322be71a0785396", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "ea026def01d1573d5e0edfb7f4e3e9453f88c43e", package = "hdk3" }
 ```
 
 Notice the match between the SHA in both cases. These should always match.

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ npm install --save-exact @holochain/conductor-api
 
 This version of `holochain-conductor-api` is currently working with `holochain/holochain` at commit:
 
-[3af5e8d6c1d7a167db808af9f2de7003a5d7bff0](https://github.com/holochain/holochain/commit/3af5e8d6c1d7a167db808af9f2de7003a5d7bff0) (Jan 9, 2021)
+[c1286bc8f41c3de5fc5823bf0ccf8869df92c548](https://github.com/holochain/holochain/commit/c1286bc8f41c3de5fc5823bf0ccf8869df92c548) (Jan 11, 2021)
 
 If updating this code, please make changes to the git `rev/sha` in 3 places:
 1. Here in the README above ^^
 2. This line in `install-holochain.sh`
 ```bash
-REV=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0
+REV=c1286bc8f41c3de5fc5823bf0ccf8869df92c548
 ```
 3. and this line in `test/e2e/fixtures/zomes/foo/Cargo.toml`
 ```
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "3af5e8d6c1d7a167db808af9f2de7003a5d7bff0", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "c1286bc8f41c3de5fc5823bf0ccf8869df92c548", package = "hdk3" }
 ```
 
 Notice the match between the SHA in both cases. These should always match.

--- a/install-holochain.sh
+++ b/install-holochain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV=3675b588de0aaf7eb9dc852b4012f3cfa5a27df7
+REV=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0
 
 cargo install --force holochain \
   --git https://github.com/holochain/holochain.git \

--- a/install-holochain.sh
+++ b/install-holochain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV=d770a2e71df9d4cc87c91b926322be71a0785396
+REV=ea026def01d1573d5e0edfb7f4e3e9453f88c43e
 
 cargo install --force holochain \
   --git https://github.com/holochain/holochain.git \

--- a/install-holochain.sh
+++ b/install-holochain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV=c1286bc8f41c3de5fc5823bf0ccf8869df92c548
+REV=d770a2e71df9d4cc87c91b926322be71a0785396
 
 cargo install --force holochain \
   --git https://github.com/holochain/holochain.git \

--- a/install-holochain.sh
+++ b/install-holochain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV=3af5e8d6c1d7a167db808af9f2de7003a5d7bff0
+REV=c1286bc8f41c3de5fc5823bf0ccf8869df92c548
 
 cargo install --force holochain \
   --git https://github.com/holochain/holochain.git \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/conductor-api",
-  "version": "0.0.1-dev.15",
+  "version": "0.0.1-dev.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/conductor-api",
-  "version": "0.0.1-dev.15",
+  "version": "0.0.1-dev.16",
   "description": "Encode/decode messages to/from the Holochain Conductor API over Websocket",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/conductor-api",
-  "version": "0.0.1-dev.16",
+  "version": "0.0.1-dev.15",
   "description": "Encode/decode messages to/from the Holochain Conductor API over Websocket",
   "repository": {
     "type": "git",

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -76,13 +76,17 @@ type InstallAppDnaPayload = {
   membrane_proof?: MembraneProof
 }
 
-type DnaSource = 
+type DnaSource =
   {
-    path: string 
+    hash: HoloHash
   }
-   | 
+  |
   {
-    wasm: DnaFile
+    path: string
+  }
+   |
+  {
+    dna_file: DnaFile
   };
 
 export interface HoloHashed<T> {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -17,8 +17,9 @@ export type GenerateAgentPubKeyRequest = void
 export type GenerateAgentPubKeyResponse = AgentPubKey
 
 export type RegisterDnaRequest = {
-    source: DnaSource,
-    properties?: DnaProperties,
+  source: DnaSource,
+  uuid?: string,
+  properties?: DnaProperties,
 }
 
 export type RegisterDnaResponse = HoloHash

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,5 +1,5 @@
 import { Requester } from "./common"
-import { AgentPubKey, MembraneProof, DnaProperties, InstalledAppId, CellId, CellNick, InstalledApp } from "./types"
+import { HoloHash, AgentPubKey, MembraneProof, DnaProperties, InstalledAppId, CellId, CellNick, InstalledApp } from "./types"
 
 export type ActivateAppRequest = { installed_app_id: InstalledAppId }
 export type ActivateAppResponse = null
@@ -15,6 +15,13 @@ export type DumpStateResponse = any
 
 export type GenerateAgentPubKeyRequest = void
 export type GenerateAgentPubKeyResponse = AgentPubKey
+
+export type RegisterDnaRequest = {
+    source: DnaSource,
+    properties?: DnaProperties,
+}
+
+export type RegisterDnaResponse = HoloHash
 
 export type InstallAppRequest = {
   installed_app_id: InstalledAppId,
@@ -51,6 +58,7 @@ export interface AdminApi {
   deactivateApp: Requester<DeactivateAppRequest, DeactivateAppResponse>
   dumpState: Requester<DumpStateRequest, DumpStateResponse>
   generateAgentPubKey: Requester<GenerateAgentPubKeyRequest, GenerateAgentPubKeyResponse>
+  registerDna: Requester<RegisterDnaRequest, RegisterDnaResponse>
   installApp: Requester<InstallAppRequest, InstallAppResponse>
   listDnas: Requester<ListDnasRequest, ListDnasResponse>
   listCellIds: Requester<ListCellIdsRequest, ListCellIdsResponse>
@@ -61,8 +69,14 @@ export interface AdminApi {
 
 
 type InstallAppDnaPayload = {
-  path: string,
+  path?: string,
+  hash?: HoloHash
   nick: CellNick,
   properties?: DnaProperties,
   membrane_proof?: MembraneProof
+}
+
+type DnaSource = {
+    path?: string,
+    hash?: HoloHash
 }

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -76,7 +76,31 @@ type InstallAppDnaPayload = {
   membrane_proof?: MembraneProof
 }
 
-type DnaSource = {
-    path?: string,
-    hash?: HoloHash
+type DnaSource = 
+  {
+    path: string 
+  }
+   | 
+  {
+    wasm: DnaFile
+  };
+
+export interface HoloHashed<T> {
+  hash: Uint8Array;
+  content: T;
 }
+
+export interface DnaFile {
+  dna: HoloHashed<DnaDef>;
+  code: Array<WasmCode>;
+}
+
+export interface DnaDef {
+  name: String;
+  uuid: String;
+  properties: Uint8Array;
+  zomes: Zomes;
+}
+
+export type Zomes = Array<[string, { wasm_hash: Array<Uint8Array> }]>;
+export type WasmCode = [Uint8Array, { code: Array<number> }];

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -90,7 +90,7 @@ type DnaSource =
   };
 
 export interface HoloHashed<T> {
-  hash: Uint8Array;
+  hash: HoloHash;
   content: T;
 }
 
@@ -102,9 +102,9 @@ export interface DnaFile {
 export interface DnaDef {
   name: String;
   uuid: String;
-  properties: Uint8Array;
+  properties: HoloHash;
   zomes: Zomes;
 }
 
-export type Zomes = Array<[string, { wasm_hash: Array<Uint8Array> }]>;
-export type WasmCode = [Uint8Array, { code: Array<number> }];
+export type Zomes = Array<[string, { wasm_hash: Array<HoloHash> }]>;
+export type WasmCode = [HoloHash, { code: Array<number> }];

--- a/src/websocket/admin.ts
+++ b/src/websocket/admin.ts
@@ -53,6 +53,8 @@ export class AdminWebsocket implements Api.AdminApi {
     = this._requester('dump_state', dumpStateTransform)
   generateAgentPubKey: Requester<Api.GenerateAgentPubKeyRequest, Api.GenerateAgentPubKeyResponse>
     = this._requester('generate_agent_pub_key')
+  registerDna: Requester<Api.RegisterDnaRequest, Api.RegisterDnaResponse>
+    = this._requester('register_dna')
   installApp: Requester<Api.InstallAppRequest, Api.InstallAppResponse>
     = this._requester('install_app')
   listDnas: Requester<Api.ListDnasRequest, Api.ListDnasResponse>

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.104"
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "c1286bc8f41c3de5fc5823bf0ccf8869df92c548", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "d770a2e71df9d4cc87c91b926322be71a0785396", package = "hdk3" }

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.104"
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "3af5e8d6c1d7a167db808af9f2de7003a5d7bff0", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "c1286bc8f41c3de5fc5823bf0ccf8869df92c548", package = "hdk3" }

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.104"
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "3675b588de0aaf7eb9dc852b4012f3cfa5a27df7", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "3af5e8d6c1d7a167db808af9f2de7003a5d7bff0", package = "hdk3" }

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.104"
-hdk3 = { git = "https://github.com/holochain/holochain", rev = "d770a2e71df9d4cc87c91b926322be71a0785396", package = "hdk3" }
+hdk3 = { git = "https://github.com/holochain/holochain", rev = "ea026def01d1573d5e0edfb7f4e3e9453f88c43e", package = "hdk3" }

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -44,12 +44,23 @@ test('admin smoke test', withConductor(ADMIN_PORT, async t => {
   await admin.attachAppInterface({ port: 0 })
   await admin.deactivateApp({ installed_app_id })
 
-  const dnas = await admin.listDnas()
+  let dnas = await admin.listDnas()
   t.equal(dnas.length, 1)
 
   const activeApps3 = await admin.listActiveApps()
   t.equal(activeApps3.length, 0)
   // NB: missing dumpState because it requires a valid cell_id
+
+  // install from hash
+  const newHash = await admin.registerDna({
+    source: {hash},
+    properties: {uuid: "123456"}
+  })
+  t.ok(newHash)
+
+  dnas = await admin.listDnas()
+  t.equal(dnas.length, 2)
+
 }))
 
 

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -19,8 +19,13 @@ test('admin smoke test', withConductor(ADMIN_PORT, async t => {
   const agent_key = await admin.generateAgentPubKey()
   t.ok(agent_key)
 
+  const path = `${FIXTURE_PATH}/test.dna.gz`;
+  const hash = await admin.registerDna({
+      source: {path}
+  })
+  t.ok(hash)
   await admin.installApp({
-    installed_app_id, agent_key, dnas: []
+      installed_app_id, agent_key, dnas: [{hash, nick: "thedna"}]
   })
 
   const activeApps1 = await admin.listActiveApps()
@@ -34,8 +39,9 @@ test('admin smoke test', withConductor(ADMIN_PORT, async t => {
 
   await admin.attachAppInterface({ port: 0 })
   await admin.deactivateApp({ installed_app_id })
+
   const dnas = await admin.listDnas()
-  t.equal(dnas.length, 0)
+  t.equal(dnas.length, 1)
 
   const activeApps3 = await admin.listActiveApps()
   t.equal(activeApps3.length, 0)

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -51,10 +51,10 @@ test('admin smoke test', withConductor(ADMIN_PORT, async t => {
   t.equal(activeApps3.length, 0)
   // NB: missing dumpState because it requires a valid cell_id
 
-  // install from hash
+  // install from hash and uuid
   const newHash = await admin.registerDna({
     source: {hash},
-    properties: {uuid: "123456"}
+    uuid: "123456"
   })
   t.ok(newHash)
 

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -68,7 +68,7 @@ test('admin register dna with full binary file', withConductor(ADMIN_PORT, async
 
   const decodedDnaFile: DnaFile  = decode(dnaFile.buffer) as DnaFile;
   const hash = await admin.registerDna({
-      source: { wasm: decodedDnaFile }
+      source: { dna_file: decodedDnaFile }
   })
   t.ok(hash)
   await admin.installApp({

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -85,13 +85,21 @@ export const installAppAndDna = async (
   const installed_app_id = 'app'
   const nick = 'mydna'
   const admin = await AdminWebsocket.connect(`http://localhost:${adminPort}`)
+
+  const path = `${FIXTURE_PATH}/test.dna.gz`;
+  const hash = await admin.registerDna({
+    source: {path}
+  })
+
+  console.log("THE HASH:", hash)
+
   const agent = await admin.generateAgentPubKey()
   const app = await admin.installApp({
     installed_app_id,
     agent_key: agent,
     dnas: [
       {
-        path: `${FIXTURE_PATH}/test.dna.gz`,
+        hash,
         nick,
       },
     ],


### PR DESCRIPTION
Holochain's ConductorAPI now includes a new function "RegisterDNA" that allows separating loading DNAs into holochains wasm database, from installing happs.  This function allows you to specify DNA by path, or as data directly when registering.  Currently one can still use the DNA path when installing a happ, but this is deprecated in favor of allways using the hash.

This PR adds support for these calls.