### PR TITLE
Don't mutate zome call args

### DIFF
--- a/src/websocket/app.ts
+++ b/src/websocket/app.ts
@@ -50,9 +50,11 @@ export class AppWebsocket implements AppApi {
 }
 
 const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Buffer>, CallZomeResponseGeneric<Buffer>, CallZomeResponseGeneric<any>> = {
-  input: (req: CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Buffer> => {
-    req.payload = msgpack.encode(req.payload)
-    return req
+  input: (req:  CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Buffer> => {
+    return {
+      ...req,
+      payload: Buffer.from(msgpack.encode(req.payload))
+    }
   },
   output: (res: CallZomeResponseGeneric<Buffer>): CallZomeResponseGeneric<any> => {
     return msgpack.decode(res)

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -166,6 +166,27 @@ test('can call a zome function', withConductor(ADMIN_PORT, async t => {
   t.equal(response, "foo")
 }))
 
+test('can call a zome function twice, reusing args', withConductor(ADMIN_PORT, async t => {
+  const [installed_app_id, cell_id, nick, client] = await installAppAndDna(ADMIN_PORT)
+  const info = await client.appInfo({ installed_app_id }, 1000)
+  t.deepEqual(info.cell_data[0].cell_id, cell_id)
+  t.equal(info.cell_data[0].cell_nick, nick)
+  const args = {
+    // TODO: write a test with a real capability secret.
+    cap: null,
+    cell_id,
+    zome_name: TEST_ZOME_NAME,
+    fn_name: 'foo',
+    provenance: fakeAgentPubKey('TODO'),
+    payload: null,
+  }
+  const response = await client.callZome(args, 30000)
+  t.equal(response, "foo")
+  const response2 = await client.callZome(args, 30000)
+  t.equal(response, "foo")
+}))
+
+
 test('can handle canceled response', withConductor(ADMIN_PORT, async t => {
   // const client = await WsClient.connect(`http://localhost:${ADMIN_PORT}`);A
   const client = new WsClient({ send: (_d) =>{} });


### PR DESCRIPTION
This fixes an issue that was showing up with Holo Hosted Apps. In Holo's infrastructure we're retrying zome calls when one fails under certain conditions, but the second one was always failing due to this bug. See the added test for an example