### PR TITLE
Removed `Buffer.from`, fixed types to align with msgpack API

### DIFF
--- a/src/websocket/app.ts
+++ b/src/websocket/app.ts
@@ -49,7 +49,7 @@ export class AppWebsocket implements AppApi {
     = this._requester('zome_call_invocation', callZomeTransform)
 }
 
-const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Uint8Array>, CallZomeResponseGeneric<Buffer>, CallZomeResponseGeneric<any>> = {
+const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Uint8Array>, CallZomeResponseGeneric<Uint8Array>, CallZomeResponseGeneric<any>> = {
   input: (req:  CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Uint8Array> => {
     return {
       ...req,

--- a/src/websocket/app.ts
+++ b/src/websocket/app.ts
@@ -49,14 +49,14 @@ export class AppWebsocket implements AppApi {
     = this._requester('zome_call_invocation', callZomeTransform)
 }
 
-const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Buffer>, CallZomeResponseGeneric<Buffer>, CallZomeResponseGeneric<any>> = {
-  input: (req:  CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Buffer> => {
+const callZomeTransform: Transformer<CallZomeRequestGeneric<any>, CallZomeRequestGeneric<Uint8Array>, CallZomeResponseGeneric<Buffer>, CallZomeResponseGeneric<any>> = {
+  input: (req:  CallZomeRequestGeneric<any>): CallZomeRequestGeneric<Uint8Array> => {
     return {
       ...req,
-      payload: Buffer.from(encode(req.payload))
+      payload: encode(req.payload)
     }
   },
-  output: (res: CallZomeResponseGeneric<Buffer>): CallZomeResponseGeneric<any> => {
+  output: (res: CallZomeResponseGeneric<Uint8Array>): CallZomeResponseGeneric<any> => {
     return decode(res)
   }
 }


### PR DESCRIPTION
All tests passing:

```
    ✔  should be truthy
    ✔  should be truthy
    ✔  should be strictly equal
    ✔  should be strictly equal
        Conductor exited with code null
        Conductor exited with code null
    ✔  should be strictly equal

passed: 55  failed: 0  of 55 tests  (25.5s)

All of 55 tests passed!
```