### PR TITLE
Switched to rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@holochain/conductor-api",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@msgpack/msgpack": "2.4.0",
         "@types/ws": "^7.2.4",
@@ -18,6 +18,7 @@
         "@types/node": "^14.0",
         "@types/tape": "^4.13.0",
         "js-yaml": "^3.14.0",
+        "rimraf": "^3.0.2",
         "tap-diff": "^0.1.1",
         "tape": "^5.0",
         "ts-node": "^8.10.2",
@@ -829,6 +830,21 @@
       "dev": true,
       "dependencies": {
         "through": "~2.3.4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
@@ -1835,6 +1851,15 @@
       "dev": true,
       "requires": {
         "through": "~2.3.4"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lib.es/**/*"
   ],
   "scripts": {
-    "build": "rm -rf ./lib ./dist && tsc -d && tsc --outDir lib.es --module es2015",
-    "dev": "rm -rf ./lib && tsc -d -w",
+    "build": "rimraf ./lib ./dist && tsc -d && tsc --outDir lib.es --module es2015",
+    "dev": "rimraf ./lib && tsc -d -w",
     "doc": "typedoc",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
@@ -36,6 +36,7 @@
     "@types/node": "^14.0",
     "@types/tape": "^4.13.0",
     "js-yaml": "^3.14.0",
+    "rimraf": "^3.0.2",
     "tap-diff": "^0.1.1",
     "tape": "^5.0",
     "ts-node": "^8.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,7 +261,7 @@
     "has" "^1.0.3"
     "has-symbols" "^1.0.1"
 
-"glob@^7.1.6":
+"glob@^7.1.3", "glob@^7.1.6":
   "integrity" "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA=="
   "resolved" "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
   "version" "7.1.6"
@@ -566,6 +566,13 @@
   "version" "0.0.0"
   dependencies:
     "through" "~2.3.4"
+
+"rimraf@^3.0.2":
+  "integrity" "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="
+  "resolved" "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  "version" "3.0.2"
+  dependencies:
+    "glob" "^7.1.3"
 
 "safe-buffer@~5.1.0", "safe-buffer@~5.1.1":
   "integrity" "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="


### PR DESCRIPTION
Using `rm -rf` in the package.json scripts causes the package to break when run in windows. `rimraf` is cross platform.