### PR TITLE
Prevent console.error from going off because it causes some problems in test code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
     'semi': ['error', 'never'],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-empty-function': 'off'
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@detools/tap-diff": "^0.2.2",
-        "@types/node": "^14.0",
+        "@types/node": "^14.17.32",
         "@types/tape": "^4.13.0",
         "@types/ws": "^7.2.4",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
@@ -312,9 +312,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+      "version": "14.17.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
+      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
       "dev": true
     },
     "node_modules/@types/tape": {
@@ -3119,9 +3119,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+      "version": "14.17.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
+      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
       "dev": true
     },
     "@types/tape": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@detools/tap-diff": "^0.2.2",
-    "@types/node": "^14.0",
+    "@types/node": "^14.17.32",
     "@types/tape": "^4.13.0",
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^4.29.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
+    "@detools/tap-diff": "^0.2.2",
     "@types/node": "^14.0",
     "@types/tape": "^4.13.0",
     "js-yaml": "^3.14.0",
     "rimraf": "^3.0.2",
-    "@detools/tap-diff": "^0.2.2",
     "tape": "^5.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.9"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run test:raw | tap-diff",
     "test:raw": "RUST_LOG=error RUST_BACKTRACE=1 ts-node test",
     "example": "ts-node examples/zome-call",
-    "lint": "eslint src/** --fix"
+    "lint": "eslint src/** test/** --fix"
   },
   "author": "",
   "dependencies": {

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -1,8 +1,8 @@
-import { InstalledAppId } from "../api/types"
-import fetch from "cross-fetch"
+import { InstalledAppId } from "../api/types";
+import fetch from "cross-fetch";
 
 // This is coupled with https://github.com/holochain/launcher/blob/develop/src-tauri/src/uis/caddy.rs#L13
-export const LAUNCHER_ENV_URL = "/.launcher-env.json"
+export const LAUNCHER_ENV_URL = "/.launcher-env.json";
 
 export interface LauncherEnvironment {
   APP_INTERFACE_PORT: number;
@@ -12,33 +12,43 @@ export interface LauncherEnvironment {
 
 async function fetchLauncherEnvironment(): Promise<
   LauncherEnvironment | undefined
-  > {
-  let env
-  try {
-    env = await fetch(LAUNCHER_ENV_URL)
-  } catch (e) {
-    return
-  }
-  if (!env.ok || env.status === 404) {
-    return
-  }
+> {
+  const env = await fetch(LAUNCHER_ENV_URL);
 
-  return await env.json()
+  if (env.ok) {
+    const launcherEnvironment = await env.json();
+    return launcherEnvironment;
+  } else {
+    // We are not in the launcher environment
+    if (env.status === 404) {
+      console.warn(
+        "[@holochain/conductor-api]: you are in a development environment. When this UI is run in the Holochain Launcher, `AppWebsocket.connect()`, `AdminWebsocket.connect()` and `appWebsocket.appInfo()` will have their parameters ignored and substituted by the ones provided by the Holochain Launcher."
+      );
+      return undefined;
+    } else {
+      throw new Error(
+        `Error trying to fetch the launcher environment: ${env.statusText}`
+      );
+    }
+  }
 }
 
-const isBrowser = typeof window !== "undefined"
-let promise: Promise<any>
+const isBrowser = typeof window !== "undefined";
+const isJest =
+  process && process.env && process.env.JEST_WORKER_ID !== undefined;
 
-if (isBrowser) {
-  promise = fetchLauncherEnvironment().catch(console.error)
+let promise: Promise<any>;
+
+if (isBrowser && !isJest) {
+  promise = fetchLauncherEnvironment().catch(console.error);
 }
 
 export async function getLauncherEnvironment(): Promise<
   LauncherEnvironment | undefined
-  > {
+> {
   if (isBrowser) {
-    return promise
+    return promise;
   } else {
-    return undefined
+    return undefined;
   }
 }

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -13,24 +13,17 @@ export interface LauncherEnvironment {
 async function fetchLauncherEnvironment(): Promise<
   LauncherEnvironment | undefined
 > {
-  const env = await fetch(LAUNCHER_ENV_URL);
-
-  if (env.ok) {
-    const launcherEnvironment = await env.json();
-    return launcherEnvironment;
-  } else {
-    // We are not in the launcher environment
-    if (env.status === 404) {
-      console.warn(
-        "[@holochain/conductor-api]: you are in a development environment. When this UI is run in the Holochain Launcher, `AppWebsocket.connect()`, `AdminWebsocket.connect()` and `appWebsocket.appInfo()` will have their parameters ignored and substituted by the ones provided by the Holochain Launcher."
-      );
-      return undefined;
-    } else {
-      throw new Error(
-        `Error trying to fetch the launcher environment: ${env.statusText}`
-      );
-    }
+  let env
+  try {
+    env = await fetch(LAUNCHER_ENV_URL);
+  } catch (e) {
+    return
   }
+  if (!env.ok || env.status === 404) {
+    return
+  }
+
+  return await env.json();
 }
 
 const isBrowser = typeof window !== "undefined";

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -1,8 +1,8 @@
-import { InstalledAppId } from "../api/types";
-import fetch from "cross-fetch";
+import { InstalledAppId } from "../api/types"
+import fetch from "cross-fetch"
 
 // This is coupled with https://github.com/holochain/launcher/blob/develop/src-tauri/src/uis/caddy.rs#L13
-export const LAUNCHER_ENV_URL = "/.launcher-env.json";
+export const LAUNCHER_ENV_URL = "/.launcher-env.json"
 
 export interface LauncherEnvironment {
   APP_INTERFACE_PORT: number;
@@ -12,43 +12,43 @@ export interface LauncherEnvironment {
 
 async function fetchLauncherEnvironment(): Promise<
   LauncherEnvironment | undefined
-> {
-  const env = await fetch(LAUNCHER_ENV_URL);
+  > {
+  const env = await fetch(LAUNCHER_ENV_URL)
 
   if (env.ok) {
-    const launcherEnvironment = await env.json();
-    return launcherEnvironment;
+    const launcherEnvironment = await env.json()
+    return launcherEnvironment
   } else {
     // We are not in the launcher environment
     if (env.status === 404) {
       console.warn(
         "[@holochain/conductor-api]: you are in a development environment. When this UI is run in the Holochain Launcher, `AppWebsocket.connect()`, `AdminWebsocket.connect()` and `appWebsocket.appInfo()` will have their parameters ignored and substituted by the ones provided by the Holochain Launcher."
-      );
-      return undefined;
+      )
+      return undefined
     } else {
       throw new Error(
         `Error trying to fetch the launcher environment: ${env.statusText}`
-      );
+      )
     }
   }
 }
 
-const isBrowser = typeof window !== "undefined";
+const isBrowser = typeof window !== "undefined"
 const isJest =
-  process && process.env && process.env.JEST_WORKER_ID !== undefined;
+  process && process.env && process.env.JEST_WORKER_ID !== undefined
 
-let promise: Promise<any>;
+let promise: Promise<any>
 
 if (isBrowser && !isJest) {
-  promise = fetchLauncherEnvironment().catch(console.error);
+  promise = fetchLauncherEnvironment().catch(console.error)
 }
 
 export async function getLauncherEnvironment(): Promise<
   LauncherEnvironment | undefined
-> {
+  > {
   if (isBrowser) {
-    return promise;
+    return promise
   } else {
-    return undefined;
+    return undefined
   }
 }

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -14,24 +14,24 @@ const writeConfig = (port, configPath) : string => {
   const dir = fs.mkdtempSync(`${os.tmpdir()}/holochain-test-`)
   const lairDir = `${dir}/keystore`
   if (!fs.existsSync(lairDir)) {
-    fs.mkdirSync(lairDir);
+    fs.mkdirSync(lairDir)
   }
 
-  let yamlStr = yaml.safeDump({
+  const yamlStr = yaml.safeDump({
     environment_path: dir,
     passphrase_service: {
       type: 'danger_insecure_from_config',
-      passphrase: 'password'
+      passphrase: 'password',
     },
     keystore_path: lairDir,
     admin_interfaces: [{
       driver: {
         type: 'websocket',
         port,
-      }
-    }]
-  });
-  fs.writeFileSync(configPath, yamlStr, 'utf8');
+      },
+    }],
+  })
+  fs.writeFileSync(configPath, yamlStr, 'utf8')
   console.info(`using database environment path: ${dir}`)
   return lairDir
 }
@@ -68,7 +68,7 @@ export const launch = async (port, configPath) => {
       // TODO: maybe put this behind a flag?
       "RUST_BACKTRACE": "1",
       ...process.env,
-    }
+    },
   })
   // Wait for lair to output data such as "#lair-keystore-ready#" before starting holochain
   await new Promise((resolve) => { lairHandle.stdout.once("data", resolve) })
@@ -102,15 +102,15 @@ export const withConductor = (port, f) => async t => {
 
 export const installAppAndDna = async (
   adminPort: number,
-  signalCb: (signal: any) => void = () => {}
-): Promise<[InstalledAppId, CellId, CellNick, AppWebsocket, AdminWebsocket]> => {
+  signalCb: (signal: any) => void = (() => {})
+): Promise<{ installed_app_id: InstalledAppId, cell_id: CellId, nick: CellNick, client: AppWebsocket, admin: AdminWebsocket}> => {
   const installed_app_id = 'app'
   const nick = 'mydna'
   const admin = await AdminWebsocket.connect(`http://localhost:${adminPort}`)
 
-  const path = `${FIXTURE_PATH}/test.dna`;
+  const path = `${FIXTURE_PATH}/test.dna`
   const hash = await admin.registerDna({
-    path
+    path,
   })
 
   console.log("THE HASH:", hash)
@@ -123,7 +123,7 @@ export const installAppAndDna = async (
       {
         hash,
         nick,
-      },
+      }
     ],
   })
   console.log("THE INSTALL RESULT:", app)
@@ -132,5 +132,5 @@ export const installAppAndDna = async (
   // destructure to get whatever open port was assigned to the interface
   const { port: appPort } = await admin.attachAppInterface({ port: 0 })
   const client = await AppWebsocket.connect(`http://localhost:${appPort}`, 12000, signalCb)
-    return [installed_app_id, cell_id, nick, client, admin]
+  return {installed_app_id, cell_id, nick, client, admin}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "types": ["node"],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,10 +97,10 @@
   "resolved" "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz"
   "version" "7.0.9"
 
-"@types/node@*", "@types/node@^14.0":
-  "integrity" "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
-  "resolved" "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz"
-  "version" "14.14.35"
+"@types/node@*", "@types/node@^14.17.32":
+  "integrity" "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+  "resolved" "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz"
+  "version" "14.17.32"
 
 "@types/tape@^4.13.0":
   "integrity" "sha512-0V8cKowBdsiA9nbxAg7531sF2cdPZNiUogcfIUeUGm+bejUBE/bvibz3rH36iQP9bQjO/sOzFwU97/uC5mCyoA=="


### PR DESCRIPTION
For example, [this CI run](https://github.com/holochain/elemental-chat-ui/runs/4025567093?check_suite_focus=true#step:5:63) fails to due to some `getFileName` error which I think is caused by the usage of `console.error`