### PR TITLE
Crash when setting up tests should cause non-zero exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "doc": "typedoc",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
-    "test": "npm run test:raw | tap-diff",
+    "test": "set -o pipefail && npm run test:raw | tap-diff",
     "test:raw": "RUST_LOG=error RUST_BACKTRACE=1 ts-node test",
     "example": "ts-node examples/zome-call",
     "lint": "eslint src/** test/** --fix"


### PR DESCRIPTION
Without this, if we crash while setting up tests, the test command will return a zero exit code, and builds will report as green.