### PR TITLE
Export appBundleWithProperties utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,7 +581,9 @@ name = "test_wasm_foo"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "rmp-serde",
  "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -720,3 +740,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,7 @@ VERSION:=$(shell npm view '@holochain/conductor-api' version)
 get-version:
 	@echo 'Version: '${VERSION}
 
-install-hc:
-	./install-holochain.sh
-
 test:
-	make install-hc
 	make test-all
 
 test-all:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "CAL 1.0",
       "dependencies": {
         "@msgpack/msgpack": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/holochain/holochain-client-js/issues"
   },
   "homepage": "https://github.com/holochain/holochain-client-js#readme",
-
   "files": [
     "lib",
     "lib.es"
@@ -25,13 +24,11 @@
   "main": "lib/index.js",
   "module": "lib.es/index.js",
   "types": "lib/index.d.ts",
-
   "scripts": {
     "lint": "eslint src/**/*.ts test/**/*.ts --fix",
     "test": "RUST_LOG=error RUST_BACKTRACE=1 ts-node test",
     "build": "rimraf ./lib ./lib.es .tsbuildinfo && tsc -b"
   },
-
   "dependencies": {
     "@msgpack/msgpack": "^2.7.1",
     "cross-fetch": "^3.1.4",

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -exo pipefail
+
 cd test/e2e/fixture/zomes/foo
 cargo build --release --target wasm32-unknown-unknown --target-dir ./target
 cd ../.. # into fixtures

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -162,7 +162,7 @@ export type InstallAppBundleRequest = {
   installed_app_id?: InstalledAppId;
 
   /// Include proof-of-membrane-membership data for cells that require it,
-  /// keyed by the CellNick specified in the app bundle manifest.
+  /// keyed by the role ID specified in the app bundle manifest.
   membrane_proofs: { [key: string]: MembraneProof };
 
   /// Optional global UID override.  If set will override the UID value for all DNAs in the bundle.

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,30 +1,16 @@
 import { decode } from '@msgpack/msgpack'
-import {
-  AppBundle,
-  AppBundleSource,
-  DnaProperties
-} from '.'
+import { AppBundle, AppBundleSource, DnaProperties } from '.'
 
 export type HappProperties = { [role_id: string]: DnaProperties }
 
 const readAppBundleFromPath = async (path: string): Promise<AppBundle> => {
   const isBrowser = typeof window !== 'undefined'
   if (isBrowser) {
-    throw new Error('todo')
+    throw new Error('Cannot read app bundle from path in browser context')
   }
-  const {
-    readFile
-  }: {
-    readFile: (path: string) => Promise<Uint8Array>
-  } = require('fs/promises')
-  const {
-    gunzip
-  }: {
-    gunzip: (
-      buffer: Uint8Array,
-      callback: (error: Error | null, result: Uint8Array) => void
-    ) => Promise<Uint8Array>
-  } = require('zlib')
+  const { promises: { readFile } } = await import('fs')
+  const { gunzip } = await import('zlib')
+
   const compressed = await readFile(path)
   const encoded: Uint8Array = await new Promise((resolve, reject) =>
     gunzip(compressed, (err, bytes) =>

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,0 +1,59 @@
+import { decode } from '@msgpack/msgpack'
+import {
+  AppBundle,
+  AppBundleSource,
+  DnaProperties
+} from '.'
+
+export type HappProperties = { [role_id: string]: DnaProperties }
+
+const readAppBundleFromPath = async (path: string): Promise<AppBundle> => {
+  const isBrowser = typeof window !== 'undefined'
+  if (isBrowser) {
+    throw new Error('todo')
+  }
+  const {
+    readFile
+  }: {
+    readFile: (path: string) => Promise<Uint8Array>
+  } = require('fs/promises')
+  const {
+    gunzip
+  }: {
+    gunzip: (
+      buffer: Uint8Array,
+      callback: (error: Error | null, result: Uint8Array) => void
+    ) => Promise<Uint8Array>
+  } = require('zlib')
+  const compressed = await readFile(path)
+  const encoded: Uint8Array = await new Promise((resolve, reject) =>
+    gunzip(compressed, (err, bytes) =>
+      err === null ? resolve(bytes) : reject(err)
+    )
+  )
+  return decode(encoded) as AppBundle
+}
+
+/// Adds properties to app bundle. Requires node if passed a path.
+export const appBundleWithProperties = async (
+  source: AppBundleSource,
+  properties: HappProperties
+): Promise<AppBundleSource> => {
+  const originalBundle =
+    'path' in source ? await readAppBundleFromPath(source.path) : source.bundle
+  return {
+    bundle: {
+      ...originalBundle,
+      manifest: {
+        ...originalBundle.manifest,
+        roles: originalBundle.manifest.roles.map(roleManifest => ({
+          ...roleManifest,
+          dna: {
+            ...roleManifest.dna,
+            properties: properties[roleManifest.id]
+          }
+        }))
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export * from './api/app'
 export * from './api/types'
 export * from './websocket/admin'
 export * from './websocket/app'
-export * from './types';
+export * from './types'
+export * from './bundle'

--- a/test/e2e/fixture/zomes/foo/Cargo.toml
+++ b/test/e2e/fixture/zomes/foo/Cargo.toml
@@ -10,4 +10,6 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 serde = "=1.0.123"
+serde_yaml = "0.8.0"
+rmp-serde = "0.15.0"
 hdk = "=0.0.118"


### PR DESCRIPTION
Currently, there is no easy way to install apps and specify properties at the same time, without using `registerDna`. This PR adds a utility function that converts an `AppBundleSource` like `{ path: "./test.happ" }` to `{ bundle: { ... } }` by parsing the happ file at that path. It then edits the bundle to add some properties, since I see that as the primary use-case for this functionality. 

This function only works in a Node environment. It would be nice if as part of our test suite, we made sure things still compiled well in a browser environment. For now I'll use a local UI to test.