### PR TITLE
Added main and modules entry points to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "engines": {
     "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
   },
+  "main": "lib/index.js",
+  "module": "lib/index.js",
   "type": "module",
   "exports": {
     ".": "./lib/index.js"


### PR DESCRIPTION
Without this, the bundling process of react's v16 (webpack 4) throws this error:

```
./node_modules/@holochain-open-dev/utils/dist/hash.js
Module not found: Can't resolve '@holochain/client' in '/home/eric/code/metacurrency/holochain/glass-bead-game/client/node_modules/@holochain-open-dev/utils/dist'
``` 

I've tested this fix in my local environment and it works.