### PR TITLE
update docs for AdminWebsocket

### DIFF
--- a/docs/API_adminwebsocket.md
+++ b/docs/API_adminwebsocket.md
@@ -22,6 +22,23 @@ Create a new connection to the given URL.
 Returns a `Promise` for a new connected instance of `AdminWebsocket`.
 
 
+## `<AdminWebsocket>.activateApp({ installed_app_id })`
+
+| :exclamation: This method is deprecated. Please use `enableApp` instead  |
+|--------------------------------------------------------------------------|
+
+Send a request to activate an installed app.
+
+- `installed_app_id` - a `string`
+
+Returns a `Promise` for the corresponding response.
+
+### Response format
+```javascript
+null
+```
+
+
 ## `<AdminWebsocket>.attachAppInterface({ port })`
 Send a request to open the given port for `AppWebsocket` connections.
 
@@ -34,6 +51,23 @@ Returns a `Promise` for the corresponding response.
 {
     "port": number,
 }
+```
+
+
+## `<AdminWebsocket>.deactivateApp({ installed_app_id })`
+
+| :exclamation: This method is deprecated. Please use `disableApp` instead  |
+|---------------------------------------------------------------------------|
+
+Send a request to disable a running app.
+
+- `installed_app_id` - a `string`
+
+Returns a `Promise` for the corresponding response.
+
+### Response format
+```javascript
+null
 ```
 
 

--- a/docs/API_adminwebsocket.md
+++ b/docs/API_adminwebsocket.md
@@ -22,19 +22,6 @@ Create a new connection to the given URL.
 Returns a `Promise` for a new connected instance of `AdminWebsocket`.
 
 
-## `<AdminWebsocket>.activateApp({ installed_app_id })`
-Send a request to activate an installed app.
-
-- `installed_app_id` - a `string`
-
-Returns a `Promise` for the corresponding response.
-
-### Response format
-```javascript
-null
-```
-
-
 ## `<AdminWebsocket>.attachAppInterface({ port })`
 Send a request to open the given port for `AppWebsocket` connections.
 
@@ -50,8 +37,8 @@ Returns a `Promise` for the corresponding response.
 ```
 
 
-## `<AdminWebsocket>.deactivateApp({ installed_app_id })`
-Send a request to deactivate a running app.
+## `<AdminWebsocket>.disableApp({ installed_app_id })`
+Send a request to disable a running app.
 
 - `installed_app_id` - a `string`
 
@@ -85,6 +72,19 @@ Returns a `Promise` for the corresponding response.
     },
     ...
 ]
+```
+
+
+## `<AdminWebsocket>.enableApp({ installed_app_id })`
+Send a request to enable an installed app.
+
+- `installed_app_id` - a `string`
+
+Returns a `Promise` for the corresponding response.
+
+### Response format
+```javascript
+null
 ```
 
 


### PR DESCRIPTION
 de/activateApp=>dis/enableApp

was deprecated back in `holochain` 0.0.102: https://github.com/holochain/holochain/blob/33f26d8f08e3c61f7981cd0a7441d479386da17a/crates/holochain/CHANGELOG.md#added