### PR TITLE
Fix missing AppAgent export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Removed
 ### Changed
+- EventEmitter -> Emittery
 ### Fixed
+- Missing export of AppAgentWebsocket
 
 ## 2022-12-07: v0.10.0
 ### Added

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./admin/index.js";
 export * from "./app/index.js";
+export * from "./app-agent/index.js";
 export { CloneId } from "./common.js";

--- a/test/e2e/app-agent-websocket.ts
+++ b/test/e2e/app-agent-websocket.ts
@@ -2,10 +2,11 @@ import test, { Test } from "tape";
 import {
   AppAgentWebsocket,
   AppCreateCloneCellRequest,
-} from "../../src/api/app-agent/index.js";
-import { AppSignal, CallZomeRequest } from "../../src/api/app/index.js";
-import { CloneId } from "../../src/api/common.js";
-import { AppEntryDef } from "../../src/hdk/entry.js";
+  AppSignal,
+  CallZomeRequest,
+  CloneId,
+  AppEntryDef
+} from "../../src/index.js";
 import { installAppAndDna, withConductor } from "./util.js";
 
 const fakeAgentPubKey = () =>

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -9,16 +9,14 @@ import {
   DumpStateResponse,
   EnableAppResponse,
   InstalledAppInfoStatus,
-} from "../../src/api/admin/index.js";
-import {
   AppSignal,
   AppWebsocket,
   CallZomeRequest,
   CreateCloneCellRequest,
-} from "../../src/api/app/index.js";
+  CloneId,
+  AppEntryDef
+} from "../../src/index.js";
 import { WsClient } from "../../src/api/client.js";
-import { CloneId } from "../../src/api/common.js";
-import { AppEntryDef } from "../../src/hdk/entry.js";
 import {
   cleanSandboxConductors,
   FIXTURE_PATH,


### PR DESCRIPTION
🤦‍♂️

Fixes missing import for AppAgentWebsocket and friends which meant you couldn't directly import it. Also updates tests so they fail when the import is missing.