### PR TITLE
Improved types for `AppAgentWebsocket`

### DIFF
--- a/src/api/app-agent/types.ts
+++ b/src/api/app-agent/types.ts
@@ -1,20 +1,22 @@
-import Emittery from "emittery";
+import Emittery, { UnsubscribeFunction } from "emittery";
 import {
   ArchiveCloneCellResponse,
   CreateCloneCellRequest,
   CreateCloneCellResponse,
 } from "..";
-import { CellId, RoleName } from "../..";
+import { RoleName } from "../..";
 import {
   CallZomeRequest,
   AppInfoResponse,
   ArchiveCloneCellRequest,
+  AppSignal,
 } from "../app";
 
-export type AppAgentCallZomeRequest = Omit<CallZomeRequest, "cell_id"> & {
-  role_name?: RoleName;
-  cell_id?: CellId;
+export type RoleNameCallZomeRequest = Omit<CallZomeRequest, "cell_id"> & {
+  role_name: RoleName;
 };
+
+export type AppAgentCallZomeRequest = CallZomeRequest | RoleNameCallZomeRequest;
 
 export type AppCreateCloneCellRequest = Omit<CreateCloneCellRequest, "app_id">;
 
@@ -23,9 +25,20 @@ export type AppArchiveCloneCellRequest = Omit<
   "app_id"
 >;
 
-export interface AppAgentClient extends Emittery {
+export interface AppAgentEvents {
+  signal: AppSignal;
+}
+
+export interface AppAgentClient {
   callZome(args: AppAgentCallZomeRequest, timeout?: number): Promise<any>;
+
+  on<Name extends keyof AppAgentEvents>(
+    eventName: Name | readonly Name[],
+    listener: (eventData: AppAgentEvents[Name]) => void | Promise<void>
+  ): UnsubscribeFunction;
+
   appInfo(): Promise<AppInfoResponse>;
+
   createCloneCell(
     args: AppCreateCloneCellRequest
   ): Promise<CreateCloneCellResponse>;


### PR DESCRIPTION
- `AppAgentWebsocket` doesn't extend `Emittery` anymore to prevent users from calling `emit('signal') themselves`.
- The `AppAgentClient` interface and `Emittery` instance now have fully type-safe events. Things like `appClient.on('some-event-that-doesnt-exist')` will throw a compile time error.