### PR TITLE
removing fetch to launcher-env.json and replacing it with taking it f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Removed
 ### Changed
+- Rremove fetch to launcher-env.json and replace it with `window.__HC_LAUNCHER_ENV__`.
 ### Fixed
 
 ## 2022-12-12: v0.10.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "CAL-1.0",
       "dependencies": {
         "@msgpack/msgpack": "^2.7.2",
-        "cross-fetch": "^3.1.5",
         "emittery": "^1.0.1",
         "isomorphic-ws": "^5.0.0",
         "lodash-es": "^4.17.21",
@@ -691,14 +690,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1966,25 +1957,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -2492,11 +2464,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "node_modules/ts-node": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
@@ -2638,20 +2605,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3247,14 +3200,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -4203,14 +4148,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -4557,11 +4494,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "ts-node": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
@@ -4656,20 +4588,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.7.2",
-    "cross-fetch": "^3.1.5",
     "emittery": "^1.0.1",
     "isomorphic-ws": "^5.0.0",
     "lodash-es": "^4.17.21",

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -1,9 +1,4 @@
 import { InstalledAppId } from "../types.js";
-import fetch from "cross-fetch";
-
-// This is based on
-// https://github.com/holochain/launcher/blob/213aae208c58f2496811d80859723b71f6750426/crates/holochain_web_app_manager/src/caddy/utils.rs#L49
-export const LAUNCHER_ENV_URL = "/.launcher-env.json";
 
 export interface LauncherEnvironment {
   APP_INTERFACE_PORT: number;
@@ -11,47 +6,13 @@ export interface LauncherEnvironment {
   INSTALLED_APP_ID: InstalledAppId;
 }
 
-async function fetchLauncherEnvironment(): Promise<
-  LauncherEnvironment | undefined
-> {
-  const env = await fetch(LAUNCHER_ENV_URL);
+export const isLauncher =
+  typeof window === "object" && "__HC_LAUNCHER_ENV__" in window;
 
-  if (env.ok) {
-    const launcherEnvironment = await env.json();
-    return launcherEnvironment;
-  } else {
-    // We are not in the launcher environment
-    if (env.status === 404) {
-      console.warn(
-        "[@holochain/conductor-api]: you are in a development environment. When this UI is run in the Holochain Launcher, `AppWebsocket.connect()`, `AdminWebsocket.connect()` and `appWebsocket.appInfo()` will have their parameters ignored and substituted by the ones provided by the Holochain Launcher."
-      );
-      return undefined;
-    } else {
-      throw new Error(
-        `Error trying to fetch the launcher environment: ${env.statusText}`
-      );
-    }
-  }
-}
-
-const isBrowser = typeof window !== "undefined";
-const isJest =
-  typeof process !== "undefined" &&
-  process.env &&
-  process.env.JEST_WORKER_ID !== undefined;
-
-let promise: Promise<any>;
-
-if (isBrowser && !isJest) {
-  promise = fetchLauncherEnvironment().catch(console.error);
-}
-
-export async function getLauncherEnvironment(): Promise<
-  LauncherEnvironment | undefined
-> {
-  if (isBrowser) {
-    return promise;
-  } else {
-    return undefined;
-  }
-}
+export const getLauncherEnvironment = (): LauncherEnvironment | undefined =>
+  isLauncher
+    ? (
+        window as Window &
+          typeof globalThis & { __HC_LAUNCHER_ENV__: LauncherEnvironment }
+      ).__HC_LAUNCHER_ENV__
+    : undefined;

--- a/test/e2e/app-agent-websocket.ts
+++ b/test/e2e/app-agent-websocket.ts
@@ -5,7 +5,7 @@ import {
   AppSignal,
   CallZomeRequest,
   CloneId,
-  AppEntryDef
+  AppEntryDef,
 } from "../../src/index.js";
 import { installAppAndDna, withConductor } from "./util.js";
 

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -14,7 +14,7 @@ import {
   CallZomeRequest,
   CreateCloneCellRequest,
   CloneId,
-  AppEntryDef
+  AppEntryDef,
 } from "../../src/index.js";
 import { WsClient } from "../../src/api/client.js";
 import {
@@ -772,9 +772,8 @@ test(
 test(
   "can restore an archived clone cell",
   withConductor(ADMIN_PORT, async (t: Test) => {
-    const { installed_app_id, role_name, client, admin } = await installAppAndDna(
-      ADMIN_PORT
-    );
+    const { installed_app_id, role_name, client, admin } =
+      await installAppAndDna(ADMIN_PORT);
     const createCloneCellParams: CreateCloneCellRequest = {
       app_id: installed_app_id,
       role_name,
@@ -815,9 +814,8 @@ test(
 test(
   "can delete archived clone cells of an app",
   withConductor(ADMIN_PORT, async (t: Test) => {
-    const { installed_app_id, role_name, client, admin } = await installAppAndDna(
-      ADMIN_PORT
-    );
+    const { installed_app_id, role_name, client, admin } =
+      await installAppAndDna(ADMIN_PORT);
     const createCloneCellParams: CreateCloneCellRequest = {
       app_id: installed_app_id,
       role_name,
@@ -837,7 +835,10 @@ test(
       clone_cell_id: cloneCell1.cell_id,
     });
 
-    await admin.deleteArchivedCloneCells({ app_id: installed_app_id, role_name });
+    await admin.deleteArchivedCloneCells({
+      app_id: installed_app_id,
+      role_name,
+    });
 
     try {
       await admin.restoreCloneCell({


### PR DESCRIPTION
…rom window.__HC_LAUNCHER_ENV__

cherrypicking that change to unblock Guillem with testing `hc launch` as part of the scaffolding tool.

Will make this js-client version incompatible with existing Launcher releases but this is already the case anyway due to holochain incompatibilities.