### PR TITLE
AppAgentWebsocket uses launcher env INSTALLED_APP_ID when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 ### Added
-- AppAgentWebsocket.connect factory function that returns a promise of an AppAgentWebsocket instance, using launchers INSTALLED_APP_ID when present.
 ### Removed
 ### Changed
-- AppAgentWebsocket constructor made private
+- AppAgentWebsocket constructor uses launcher env.INSTALLED_APP_ID when present
 ### Fixed
 
 ## 2022-12-14: v0.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 ### Added
+- AppAgentWebsocket.connect factory function that returns a promise of an AppAgentWebsocket instance, using launchers INSTALLED_APP_ID when present.
 ### Removed
 ### Changed
+- AppAgentWebsocket constructor made private
 ### Fixed
 
 ## 2022-12-14: v0.10.4

--- a/docs/API_appagentwebsocket.md
+++ b/docs/API_appagentwebsocket.md
@@ -1,22 +1,12 @@
 [back to API.md](API.md)
 
 
-# `AppAgentWebsocket`
+# `new AppAgentWebsocket( appWs, installedAppId )`
 A class for interacting with Conductor's app API, restricted to a specific installed app.
 This is useful for simplifying zome and app info calls, and especially because it shares an interface (`AppAgentClient`) with the holo WebSdk client, meaning you can use this client to write the majority of your UI agnostic as to wether it's in a pure holochain or holo context.
 
-**Instance properties**
-
-- `<AppAgentWebsocket>.appWebsocket` - the AppWebsocket instance that all calls are forwarded to.
-- `<AppAgentWebsocket>.installedAppId` - the InstalledAppId that all calls are restricted to
-
-## `AppAgentWebsocket.connect( appWebsocket, installedAppId )`
-Factory function for creating an AppAgentWebsocket
-
 - `appWebsocket` - an instance of AppWebsocket, connecting to an app port on your conductor
-- `appappWebsocketWs` - the InstalledAppId that all calls will be restricted to
-
-Returns a promise of an instance of AppAgentWebsocket
+- `installedAppId` - an InstalledAppId to restrict all calls to
 
 **Instance properties**
 
@@ -94,6 +84,16 @@ Returns a `Promise` containing the cloned cell
 ```javascript
 {
   cell_id: CellId,
+  role_name: RoleName
+}
+```
+
+## `<AppAgentWebsocket>.archiveClonedCell({ clone_cell_id })`
+
+
+- `clone_cell_id?` - either a `CellId` (see `callZome` above) or a `RoleName` string, specifying the cell to be archived
+
+Returns a void `Promise`.
   role_name: RoleName
 }
 ```

--- a/docs/API_appagentwebsocket.md
+++ b/docs/API_appagentwebsocket.md
@@ -1,11 +1,22 @@
 [back to API.md](API.md)
 
 
-# `new AppAgentWebsocket( appWs )`
+# `AppAgentWebsocket`
 A class for interacting with Conductor's app API, restricted to a specific installed app.
 This is useful for simplifying zome and app info calls, and especially because it shares an interface (`AppAgentClient`) with the holo WebSdk client, meaning you can use this client to write the majority of your UI agnostic as to wether it's in a pure holochain or holo context.
 
-- `appWs` - an instance of AppWebsocket, connecting to an app port on your conductor
+**Instance properties**
+
+- `<AppAgentWebsocket>.appWebsocket` - the AppWebsocket instance that all calls are forwarded to.
+- `<AppAgentWebsocket>.installedAppId` - the InstalledAppId that all calls are restricted to
+
+## `AppAgentWebsocket.connect( appWebsocket, installedAppId )`
+Factory function for creating an AppAgentWebsocket
+
+- `appWebsocket` - an instance of AppWebsocket, connecting to an app port on your conductor
+- `appappWebsocketWs` - the InstalledAppId that all calls will be restricted to
+
+Returns a promise of an instance of AppAgentWebsocket
 
 **Instance properties**
 

--- a/src/api/admin/websocket.ts
+++ b/src/api/admin/websocket.ts
@@ -36,7 +36,7 @@ export class AdminWebsocket implements Api.AdminApi {
     defaultTimeout?: number
   ): Promise<AdminWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
-    const env = await getLauncherEnvironment();
+    const env = getLauncherEnvironment();
 
     if (env) {
       url = `ws://localhost:${env.ADMIN_INTERFACE_PORT}`;

--- a/src/api/app-agent/websocket.ts
+++ b/src/api/app-agent/websocket.ts
@@ -50,14 +50,11 @@ export class AppAgentWebsocket implements AppAgentClient {
 
   emitter = new Emittery<AppAgentEvents>();
 
-  constructor(
-    appWebsocket: AppWebsocket,
-    installedAppId: InstalledAppId
-  ) {
+  constructor(appWebsocket: AppWebsocket, installedAppId: InstalledAppId) {
     this.appWebsocket = appWebsocket;
 
     const env = getLauncherEnvironment();
-    this.installedAppId = env?.INSTALLED_APP_ID || installedAppId
+    this.installedAppId = env?.INSTALLED_APP_ID || installedAppId;
 
     this.appWebsocket.on("signal", (signal) =>
       this.emitter.emit("signal", signal)

--- a/src/api/app-agent/websocket.ts
+++ b/src/api/app-agent/websocket.ts
@@ -22,6 +22,7 @@
 
 import Emittery, { UnsubscribeFunction } from "emittery";
 import { omit } from "lodash-es";
+import { getLauncherEnvironment } from "../../environments/launcher.js";
 
 import { InstalledAppId } from "../../types.js";
 import {
@@ -49,12 +50,28 @@ export class AppAgentWebsocket implements AppAgentClient {
 
   emitter = new Emittery<AppAgentEvents>();
 
-  constructor(appWebsocket: AppWebsocket, installedAppId: InstalledAppId) {
+  private constructor(
+    appWebsocket: AppWebsocket,
+    installedAppId: InstalledAppId
+  ) {
     this.appWebsocket = appWebsocket;
+
     this.installedAppId = installedAppId;
 
     this.appWebsocket.on("signal", (signal) =>
       this.emitter.emit("signal", signal)
+    );
+  }
+
+  static async connect(
+    appWebsocket: AppWebsocket,
+    installedAppId: InstalledAppId
+  ): Promise<AppAgentWebsocket> {
+    const env = await getLauncherEnvironment();
+
+    return new AppAgentWebsocket(
+      appWebsocket,
+      env?.INSTALLED_APP_ID || installedAppId
     );
   }
 

--- a/src/api/app-agent/websocket.ts
+++ b/src/api/app-agent/websocket.ts
@@ -50,28 +50,17 @@ export class AppAgentWebsocket implements AppAgentClient {
 
   emitter = new Emittery<AppAgentEvents>();
 
-  private constructor(
+  constructor(
     appWebsocket: AppWebsocket,
     installedAppId: InstalledAppId
   ) {
     this.appWebsocket = appWebsocket;
 
-    this.installedAppId = installedAppId;
+    const env = getLauncherEnvironment();
+    this.installedAppId = env?.INSTALLED_APP_ID || installedAppId
 
     this.appWebsocket.on("signal", (signal) =>
       this.emitter.emit("signal", signal)
-    );
-  }
-
-  static async connect(
-    appWebsocket: AppWebsocket,
-    installedAppId: InstalledAppId
-  ): Promise<AppAgentWebsocket> {
-    const env = await getLauncherEnvironment();
-
-    return new AppAgentWebsocket(
-      appWebsocket,
-      env?.INSTALLED_APP_ID || installedAppId
     );
   }
 

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -64,7 +64,7 @@ export class AppWebsocket extends Emittery implements AppApi {
     signalCb?: AppSignalCb
   ): Promise<AppWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
-    const env = await getLauncherEnvironment();
+    const env = getLauncherEnvironment();
 
     if (env) {
       url = `ws://localhost:${env.APP_INTERFACE_PORT}`;

--- a/test/e2e/app-agent-websocket.ts
+++ b/test/e2e/app-agent-websocket.ts
@@ -29,7 +29,7 @@ test(
     const { installed_app_id, cell_id, role_name, client, admin } =
       await installAppAndDna(ADMIN_PORT);
 
-    const appAgentWs = await AppAgentWebsocket.connect(
+    const appAgentWs = new AppAgentWebsocket(
       client,
       installed_app_id
     );
@@ -99,7 +99,7 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = await AppAgentWebsocket.connect(
+    const appAgentWs = new AppAgentWebsocket(
       client,
       installed_app_id
     );
@@ -127,7 +127,7 @@ test(
     );
     const info = await client.appInfo({ installed_app_id });
 
-    const appAgentWs = await AppAgentWebsocket.connect(
+    const appAgentWs = new AppAgentWebsocket(
       client,
       installed_app_id
     );
@@ -171,7 +171,7 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = await AppAgentWebsocket.connect(
+    const appAgentWs = new AppAgentWebsocket(
       client,
       installed_app_id
     );

--- a/test/e2e/app-agent-websocket.ts
+++ b/test/e2e/app-agent-websocket.ts
@@ -29,7 +29,10 @@ test(
     const { installed_app_id, cell_id, role_name, client, admin } =
       await installAppAndDna(ADMIN_PORT);
 
-    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
+    const appAgentWs = await AppAgentWebsocket.connect(
+      client,
+      installed_app_id
+    );
 
     let info = await appAgentWs.appInfo();
     t.deepEqual(info.cell_data[0].cell_id, cell_id);
@@ -96,7 +99,10 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
+    const appAgentWs = await AppAgentWebsocket.connect(
+      client,
+      installed_app_id
+    );
 
     appAgentWs.on("signal", signalCb);
 
@@ -121,7 +127,10 @@ test(
     );
     const info = await client.appInfo({ installed_app_id });
 
-    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
+    const appAgentWs = await AppAgentWebsocket.connect(
+      client,
+      installed_app_id
+    );
 
     const createCloneCellParams: AppCreateCloneCellRequest = {
       role_name,
@@ -162,7 +171,10 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
+    const appAgentWs = await AppAgentWebsocket.connect(
+      client,
+      installed_app_id
+    );
 
     const createCloneCellParams: AppCreateCloneCellRequest = {
       role_name,

--- a/test/e2e/app-agent-websocket.ts
+++ b/test/e2e/app-agent-websocket.ts
@@ -29,10 +29,7 @@ test(
     const { installed_app_id, cell_id, role_name, client, admin } =
       await installAppAndDna(ADMIN_PORT);
 
-    const appAgentWs = new AppAgentWebsocket(
-      client,
-      installed_app_id
-    );
+    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
 
     let info = await appAgentWs.appInfo();
     t.deepEqual(info.cell_data[0].cell_id, cell_id);
@@ -99,10 +96,7 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = new AppAgentWebsocket(
-      client,
-      installed_app_id
-    );
+    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
 
     appAgentWs.on("signal", signalCb);
 
@@ -127,10 +121,7 @@ test(
     );
     const info = await client.appInfo({ installed_app_id });
 
-    const appAgentWs = new AppAgentWebsocket(
-      client,
-      installed_app_id
-    );
+    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
 
     const createCloneCellParams: AppCreateCloneCellRequest = {
       role_name,
@@ -171,10 +162,7 @@ test(
       ADMIN_PORT
     );
 
-    const appAgentWs = new AppAgentWebsocket(
-      client,
-      installed_app_id
-    );
+    const appAgentWs = new AppAgentWebsocket(client, installed_app_id);
 
     const createCloneCellParams: AppCreateCloneCellRequest = {
       role_name,


### PR DESCRIPTION
`AppAgentWebsocket` now checks the launcher env for `INSTALLED_APP_ID` and uses it when present. This means `AppAgentWebsocket` will work as expected in UIs running in launcher.