### PR TITLE
fix `functions` parameter type in `authorizeNewSigningKeyPair`

### DIFF
--- a/src/api/zome-call-signing.ts
+++ b/src/api/zome-call-signing.ts
@@ -26,7 +26,7 @@ const signingProps: Map<
 export const authorizeNewSigningKeyPair = async (
   adminWs: AdminWebsocket,
   cellId: CellId,
-  functions: [[ZomeName, FunctionName]]
+  functions: [ZomeName, FunctionName][]
 ) => {
   const [keyPair, signingKey] = generateSigningKeyPair();
   const capSecret = await grantSigningKey(


### PR DESCRIPTION
There is an error with the `functions` parameter type in `authorizeNewSigningKeyPair`. It should be `[string, string][]` (an array of a `[string, string]` tuple) instead of `[[string, string]]` (a tuple inside a tuple), otherwise it leads to errors like this:
![image](https://user-images.githubusercontent.com/39413655/208566915-459ecec8-60d2-4554-8cba-fb2ffbf28003.png)
