### PR TITLE
Optional LauncherEnv parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Removed
 ### Changed
+- All Launcher environment properties to be optional.
 ### Fixed
 
 ## 2022-12-23: v0.11.9

--- a/src/api/admin/websocket.ts
+++ b/src/api/admin/websocket.ts
@@ -79,7 +79,7 @@ export class AdminWebsocket implements AdminApi {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
-    if (env && env.ADMIN_INTERFACE_PORT) {
+    if (env?.ADMIN_INTERFACE_PORT) {
       url = `ws://127.0.0.1:${env.ADMIN_INTERFACE_PORT}`;
     }
 

--- a/src/api/admin/websocket.ts
+++ b/src/api/admin/websocket.ts
@@ -38,7 +38,7 @@ export class AdminWebsocket implements Api.AdminApi {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
-    if (env) {
+    if (env && env.ADMIN_INTERFACE_PORT) {
       url = `ws://127.0.0.1:${env.ADMIN_INTERFACE_PORT}`;
     }
 

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -62,12 +62,12 @@ export class AppWebsocket extends Emittery implements AppApi {
   static async connect(
     url: string,
     defaultTimeout?: number,
-    signalCb?: AppSignalCb,
+    signalCb?: AppSignalCb
   ): Promise<AppWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
-    if (env && env.APP_INTERFACE_PORT) {
+    if (env?.APP_INTERFACE_PORT) {
       url = `ws://127.0.0.1:${env.APP_INTERFACE_PORT}`;
     }
 
@@ -81,7 +81,7 @@ export class AppWebsocket extends Emittery implements AppApi {
     const appWebsocket = new AppWebsocket(
       wsClient,
       defaultTimeout,
-      env ? env.INSTALLED_APP_ID : undefined
+      env?.INSTALLED_APP_ID
     );
 
     wsClient.on("signal", (signal) => appWebsocket.emit("signal", signal));

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -55,12 +55,13 @@ export class AppWebsocket extends Emittery implements AppApi {
   static async connect(
     url: string,
     defaultTimeout?: number,
-    signalCb?: AppSignalCb
+    signalCb?: AppSignalCb,
+    ignoreLauncherEnvUrl?: boolean
   ): Promise<AppWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
-    if (env) {
+    if (env && !ignoreLauncherEnvUrl) {
       url = `ws://127.0.0.1:${env.APP_INTERFACE_PORT}`;
     }
 

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -56,12 +56,11 @@ export class AppWebsocket extends Emittery implements AppApi {
     url: string,
     defaultTimeout?: number,
     signalCb?: AppSignalCb,
-    ignoreLauncherEnvUrl?: boolean
   ): Promise<AppWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
-    if (env && !ignoreLauncherEnvUrl) {
+    if (env && env.APP_INTERFACE_PORT) {
       url = `ws://127.0.0.1:${env.APP_INTERFACE_PORT}`;
     }
 

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -7,7 +7,7 @@ import {
   getNonceExpiration,
   randomNonce,
 } from "../api/index.js";
-import { encode } from "js-base64";
+import { encode } from "@msgpack/msgpack";
 
 export interface LauncherEnvironment {
   APP_INTERFACE_PORT: number;

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -10,9 +10,9 @@ import {
 import { encode } from "@msgpack/msgpack";
 
 export interface LauncherEnvironment {
-  APP_INTERFACE_PORT: number;
-  ADMIN_INTERFACE_PORT: number;
-  INSTALLED_APP_ID: InstalledAppId;
+  APP_INTERFACE_PORT?: number;
+  ADMIN_INTERFACE_PORT?: number;
+  INSTALLED_APP_ID?: InstalledAppId;
 }
 
 const __HC_LAUNCHER_ENV__ = "__HC_LAUNCHER_ENV__";


### PR DESCRIPTION
The launcher admin window needs a way to use the js-client where the js-client recognizes that it's in a launcher environment, i.e. passes zome calls for signing to tauri, but at the same time does not take the websocket URL from `window.__HC_LAUNCH_ENV__` but uses the one passed as an argument to the `.connect()` method. This is because the launcher admin window needs to be able to connect to multiple holochain versions from within the same window.

My first solution used an optional `ignoreLauncherEnv` argument in the connect method (ddd457e01d6051de5d7edf2ffd2074d97d961ce4) but then I realized that it's probably cleaner to solve it by making the attributes of the `LauncherEnv` interface optional (250004179a0b0edaaab36da079be0f7a400fcd94).