### PR TITLE
stringify error responses such that they are readable in the browser console

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -51,7 +51,7 @@ const identityTransformer = {
 };
 
 export const catchError = (res: any) => {
-  return res.type === ERROR_TYPE ? Promise.reject(res) : Promise.resolve(res);
+  return res.type === ERROR_TYPE ? Promise.reject(JSON.stringify(res)) : Promise.resolve(res);
 };
 
 export const promiseTimeout = (


### PR DESCRIPTION
I kept getting errors of the kind `unresolved Promise rejection: [Object Object]` for failing zome calls which were really unhelpful and I figured out that stringifying the result in the error case solves that.