### PR TITLE
fix: error handling for localhost

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -111,6 +111,9 @@ export class WsClient extends Emittery {
    */
   static connect(url: string) {
     return new Promise<WsClient>((resolve, reject) => {
+      if (url.includes("localhost")) {
+        throw new Error('localhost is not supported in the url. Use "127.0.0.1" instead.');
+      }
       const socket = new IsoWebSocket(url);
       // make sure that there are no uncaught connection
       // errors because that causes nodejs thread to crash


### PR DESCRIPTION
Passing `localhost` does not work for hc sandbox running inside nix develop. Use `127.0.0.1` instead. Not sure if this change is needed maybe we can just update the docs to capture that