### PR TITLE
Add workaround for cell_id being a proxy object in Vue

### DIFF
--- a/src/api/app-agent/websocket.ts
+++ b/src/api/app-agent/websocket.ts
@@ -163,7 +163,7 @@ export class AppAgentWebsocket implements AppAgentClient {
       const zomeCallPayload: CallZomeRequest = {
         ...omit(request, "role_name"),
         provenance: this.myPubKey,
-        cell_id,
+        cell_id: [cell_id[0], cell_id[1]],
       };
       return this.appWebsocket.callZome(zomeCallPayload, timeout);
     } else if ("cell_id" in request && request.cell_id) {


### PR DESCRIPTION
Adds a workaround for the case where the `AppAgentClient` is used as a proxy object in Vue and therefore the `cell_id` is passed as a proxy object to callZome instead of a normal javascript array.