### PR TITLE
fix: run all tests in test/e2e/index, not just one

### DIFF
--- a/test/e2e/fixture/zomes/foo/src/lib.rs
+++ b/test/e2e/fixture/zomes/foo/src/lib.rs
@@ -84,6 +84,7 @@ pub fn decode_as_dnahash(bytes: Vec<u8>) -> ExternResult<DnaHash> {
     DnaHash::from_raw_39(bytes).map_err(|e| wasm_error!(WasmErrorInner::Guest(format!("{}", e))))
 }
 
+#[hdk_extern]
 pub fn create_and_get_link(tag: Vec<u8>) -> ExternResult<Link> {
     let link_base = agent_info()?.agent_latest_pubkey;
     let link_target = link_base.clone();

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -764,7 +764,7 @@ test(
   })
 );
 
-test.only(
+test(
   "create and delete link",
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);


### PR DESCRIPTION
Only this single test was being executed when running `npm run test` @jost-s 