### PR TITLE
Fix bad dir imports

### DIFF
--- a/.github/workflows/bundling-test.yml
+++ b/.github/workflows/bundling-test.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build client library
         run: npm run build
 
+      - name: Ensure Node.js can load the built client library
+        run: node lib/index.js
+
       - name: Create package tarball
         run: npm pack
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,7 +65,7 @@ jobs:
         run: nix develop -c $SHELL -c "npm ci"
 
       - name: Run tests
-        run: nix develop --override-input versions/holochain "github:holochain/holochain/holochain-0.3.0-beta-dev.48" -c $SHELL -c "npm t"
+        run: nix develop -c $SHELL -c "npm t"
 
       - name: Setup tmate session if a previous step failed
         if: ${{ failure() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 ### Fixed
+- Invalid module references which caused the client to fail to import in Node environments.
+
 ### Removed
 
 ## 2024-04-26: v0.17.0-dev.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 ### Fixed
-- Invalid module references which caused the client to fail to import in Node environments.
-
 ### Removed
+
+## 2024-04-27: v0.17.0-dev.12
+### Fixed
+- Invalid module references which caused the client to fail to import in Node environments.
 
 ## 2024-04-26: v0.17.0-dev.11
 ### Changed

--- a/docs/client.appwebsocketconnectionoptions.md
+++ b/docs/client.appwebsocketconnectionoptions.md
@@ -4,6 +4,7 @@
 
 ## AppWebsocketConnectionOptions interface
 
+
 **Signature:**
 
 ```typescript

--- a/docs/client.md
+++ b/docs/client.md
@@ -547,6 +547,7 @@ Description
 </td><td>
 
 
+
 </td></tr>
 <tr><td>
 

--- a/flake.lock
+++ b/flake.lock
@@ -141,16 +141,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1713315590,
-        "narHash": "sha256-hWeNAq+F1rAoYulPFqpQOo0cjeMZVvKXLohnP0MOc9Y=",
+        "lastModified": 1714046698,
+        "narHash": "sha256-vGOWRJXR64qXRe4MCg13xNyww904KPFvYZIQyRhuPsU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d8715775f359211b7031f4bdca1cc89db679ed10",
+        "rev": "b48562aa081b1dd177ec43035650262fbdb40d0e",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.0-beta-dev.46",
+        "ref": "holochain-0.3.0-beta-dev.48",
         "repo": "holochain",
         "type": "github"
       }
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714026619,
-        "narHash": "sha256-5zczpGhXuFoj/Lvnr9/5pqYGbJtAjYRHrNThI87Jyiw=",
+        "lastModified": 1714156903,
+        "narHash": "sha256-MFn2pqKVDflAEOJlJsvmyQMapZt/GKhwJU5sk2K17/8=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d848604f247b6b64e126a7347cc68d04bf23d76c",
+        "rev": "164dc233fdc778dce3978a2014b2fd8a5df7fcd8",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713895582,
-        "narHash": "sha256-cfh1hi+6muQMbi9acOlju3V1gl8BEaZBXBR9jQfQi4U=",
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "572af610f6151fd41c212f897c71f7056e3fb518",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714011248,
-        "narHash": "sha256-vKk9IOxZJ52Ao3uIRIjHRYYe+IpVOY6NzwToSxaO1J0=",
+        "lastModified": 1714097613,
+        "narHash": "sha256-044xbpBszupqN3nl/CGOCJtTQ4O6Aca81mJpX45i8/I=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9a2a11479b94afaf1ecc46384b27abda0d3d5f9d",
+        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1714026619,
-        "narHash": "sha256-5zczpGhXuFoj/Lvnr9/5pqYGbJtAjYRHrNThI87Jyiw=",
+        "lastModified": 1714156903,
+        "narHash": "sha256-MFn2pqKVDflAEOJlJsvmyQMapZt/GKhwJU5sk2K17/8=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d848604f247b6b64e126a7347cc68d04bf23d76c",
+        "rev": "164dc233fdc778dce3978a2014b2fd8a5df7fcd8",
         "type": "github"
       },
       "original": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.17.0-dev.11",
+  "version": "0.17.0-dev.12",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -1,4 +1,4 @@
-import { Action, DhtOp, Entry, ZomeCallCapGrant } from "../../hdk";
+import { Action, DhtOp, Entry, ZomeCallCapGrant } from "../../hdk/index.js";
 import {
   ActionHash,
   AgentPubKey,

--- a/src/api/admin/websocket.ts
+++ b/src/api/admin/websocket.ts
@@ -3,7 +3,7 @@ import {
   CapSecret,
   GrantedFunctions,
   GrantedFunctionsType,
-} from "../../hdk/capabilities.js";
+} from "../../hdk/index.js";
 import type { AgentPubKey, CellId } from "../../types.js";
 import { WsClient } from "../client.js";
 import {

--- a/src/api/app/types.ts
+++ b/src/api/app/types.ts
@@ -285,6 +285,9 @@ export interface AppClient {
   networkInfo(args: AppNetworkInfoRequest): Promise<NetworkInfoResponse>;
 }
 
+/**
+ * @public
+ */
 export interface AppWebsocketConnectionOptions
   extends WebsocketConnectionOptions {
   token?: AppAuthenticationToken;

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -1,8 +1,7 @@
 import Emittery, { UnsubscribeFunction } from "emittery";
 import { omit } from "lodash-es";
-
 import { AgentPubKey, CellId, RoleName } from "../../types.js";
-import { AppInfo, CellType } from "../admin";
+import { AppInfo, CellType } from "../admin/index.js";
 import {
   catchError,
   DEFAULT_TIMEOUT,
@@ -43,17 +42,17 @@ import {
 import {
   getHostZomeCallSigner,
   getLauncherEnvironment,
-} from "../../environments/launcher";
+} from "../../environments/launcher.js";
 import { decode, encode } from "@msgpack/msgpack";
 import {
   getNonceExpiration,
   getSigningCredentials,
   randomNonce,
-} from "../zome-call-signing";
-import { encodeHashToBase64 } from "../../utils";
+} from "../zome-call-signing.js";
+import { encodeHashToBase64 } from "../../utils/index.js";
 import { hashZomeCall } from "@holochain/serialization";
 import _sodium from "libsodium-wrappers";
-import { WsClient } from "../client";
+import { WsClient } from "../client.js";
 
 /**
  * A class to establish a websocket connection to an App interface, for a

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,8 +2,8 @@ import { decode, encode } from "@msgpack/msgpack";
 import Emittery from "emittery";
 import IsoWebSocket from "isomorphic-ws";
 import { HolochainError, WsClientOptions } from "./common.js";
-import { AppAuthenticationToken } from "./admin";
-import { AppSignal, Signal, SignalType } from "./app";
+import { AppAuthenticationToken } from "./admin/index.js";
+import { AppSignal, Signal, SignalType } from "./app/index.js";
 
 interface HolochainMessage {
   id: number;

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -1,5 +1,8 @@
-import { AppAuthenticationToken, CallZomeRequest } from "../api";
-import { CallZomeRequestSigned, CallZomeRequestUnsigned } from "../api";
+import { AppAuthenticationToken, CallZomeRequest } from "../api/index.js";
+import {
+  CallZomeRequestSigned,
+  CallZomeRequestUnsigned,
+} from "../api/index.js";
 import { InstalledAppId } from "../types.js";
 
 export interface LauncherEnvironment {

--- a/src/hdk/capabilities.ts
+++ b/src/hdk/capabilities.ts
@@ -1,4 +1,4 @@
-import { FunctionName, ZomeName } from "../api/admin/types.js";
+import { FunctionName, ZomeName } from "../api/admin/index.js";
 import { AgentPubKey } from "../types.js";
 
 /**


### PR DESCRIPTION
My IDE thought (wrongly) that because the project uses TypeScript, that dir imports are valid. They are not once the library is built and running as a JS dependency!

I've updated CI with a check that would have caught this mistake.