### PR TITLE
Add missing `base` field in the Link interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 ### Added
+- Added missing `base` field to the `Link` type. This exists in Holochain but wasn't present in the client.
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/hdk/link.ts
+++ b/src/hdk/link.ts
@@ -53,6 +53,7 @@ export type RateUnits = number;
  */
 export interface Link {
   author: AgentPubKey;
+  base: AnyLinkableHash;
   target: AnyLinkableHash;
   timestamp: Timestamp;
   zome_index: ZomeIndex;


### PR DESCRIPTION
This was added to Holochain here https://github.com/holochain/holochain/pull/2573 but never updated in the client.