### PR TITLE
improve Signal type

### DIFF
--- a/src/api/app/types.ts
+++ b/src/api/app/types.ts
@@ -247,24 +247,21 @@ export const SignalType = {
 /**
  * @public
  */
-export type RawSignal =
-  | {
-      [SignalType.App]: EncodedAppSignal;
-    }
-  | {
-      [SignalType.System]: SystemSignal;
-    };
+export type SignalTypeValues = (typeof SignalType)[keyof typeof SignalType];
 
 /**
  * @public
  */
-export type Signal =
-  | {
-      [SignalType.App]: AppSignal;
-    }
-  | {
-      [SignalType.System]: SystemSignal;
-    };
+export type RawSignal = {
+  [K in SignalTypeValues]: K extends "App" ? AppSignal : SystemSignal;
+};
+
+/**
+ * @public
+ */
+export type Signal = {
+  [K in SignalTypeValues]: K extends "App" ? AppSignal : SystemSignal;
+};
 
 /**
  * @public

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,7 +3,13 @@ import Emittery from "emittery";
 import IsoWebSocket from "isomorphic-ws";
 import { HolochainError, WsClientOptions } from "./common.js";
 import { AppAuthenticationToken } from "./admin/index.js";
-import { AppSignal, RawSignal, Signal, SignalType } from "./app/index.js";
+import {
+  AppSignal,
+  EncodedAppSignal,
+  RawSignal,
+  Signal,
+  SignalType,
+} from "./app/index.js";
 
 interface HolochainMessage {
   id: number;
@@ -93,7 +99,8 @@ export class WsClient extends Emittery {
             System: deserializedSignal[SignalType.System],
           } as Signal);
         } else {
-          const encodedAppSignal = deserializedSignal[SignalType.App];
+          const encodedAppSignal: EncodedAppSignal =
+            deserializedSignal[SignalType.App];
 
           // In order to return readable content to the UI, the signal payload must also be deserialized.
           const payload = decode(encodedAppSignal.signal);

--- a/test/e2e/app-websocket.ts
+++ b/test/e2e/app-websocket.ts
@@ -6,7 +6,6 @@ import {
   AppWebsocket,
   AppCreateCloneCellRequest,
   AppEntryDef,
-  AppSignal,
   CellType,
   CloneId,
   fakeAgentPubKey,
@@ -149,7 +148,7 @@ test(
     await admin.enableApp({ installed_app_id: app_id1 });
 
     let received1 = false;
-    const signalCb1: AppSignal = () => {
+    const signalCb1: SignalCb = () => {
       received1 = true;
     };
 
@@ -164,7 +163,7 @@ test(
     await admin.enableApp({ installed_app_id: app_id2 });
 
     let received2 = false;
-    const signalCb2: AppSignal = () => {
+    const signalCb2: SignalCb = () => {
       received2 = true;
     };
 


### PR DESCRIPTION
This PR attempts to address an issue with the `Signal` type that was causing lack of intellisense and type errors when accessing properties like `signal.App` of the `SignalCb` type.

```ts
client?.on("signal", (signal) {
    console.log(signal.App.zome_name) // Property 'App' does not exist on type 'Signal'. Property 'App' does not exist on type '{ System: SystemSignal; }'
 });
```