### PR TITLE
chore(release): v0.19.0-dev.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Updates the `AppBundleSource` type according to Holochain PR [#4651](https://github.com/holochain/holochain/issues/4651) and adjusts the tests accordingly.
-### Removed
 
 ## 2025-02-20: v0.19.0-dev.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Fixed
 ### Changed
-- Updates the AppBundleSource type according to Holochain PR [#4651](https://github.com/holochain/holochain/issues/4651) and adjusts the tests accordingly.
+### Removed
+
+## 2025-03-11: v0.19.0-dev.8
+
+### Changed
+- Updates the `AppBundleSource` type according to Holochain PR [#4651](https://github.com/holochain/holochain/issues/4651) and adjusts the tests accordingly.
 ### Removed
 
 ## 2025-02-20: v0.19.0-dev.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.19.0-dev.7",
+  "version": "0.19.0-dev.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.19.0-dev.7",
+      "version": "0.19.0-dev.8",
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.19.0-dev.7",
+  "version": "0.19.0-dev.8",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",


### PR DESCRIPTION
### Summary
Release 0.19.0-dev.8

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)
