### PR TITLE
Feat/await launcher env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 ### Added
+- Add new magic configuration variable `window.__HC_AWAIT_LAUNCHER_ENV__`. If this variable is defined, then `AppWebsocket` and `AdminWebsocket`s' `connect` function will poll for `window.__HC_LAUNCHER_ENV__`, until a timeout is reached. This allows `window.__HC_LAUNCHER_ENV__` to be defined shortly *after* `connect` is called.
+
 ### Fixed
 ### Changed
 ### Removed

--- a/src/api/admin/websocket.ts
+++ b/src/api/admin/websocket.ts
@@ -1,4 +1,4 @@
-import { getLauncherEnvironment } from "../../environments/launcher.js";
+import { launcherEnv } from "../../environments/launcher.js";
 import {
   CapSecret,
   GrantedFunctions,
@@ -104,7 +104,7 @@ export class AdminWebsocket implements AdminApi {
     options: WebsocketConnectionOptions = {}
   ): Promise<AdminWebsocket> {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
-    const env = getLauncherEnvironment();
+    const env = await launcherEnv();
 
     if (env?.ADMIN_INTERFACE_PORT) {
       options.url = new URL(`ws://localhost:${env.ADMIN_INTERFACE_PORT}`);

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -54,7 +54,7 @@ import {
 } from "./types.js";
 import {
   getHostZomeCallSigner,
-  getLauncherEnvironment,
+  launcherEnv,
 } from "../../environments/launcher.js";
 import { decode, encode } from "@msgpack/msgpack";
 import {
@@ -224,7 +224,7 @@ export class AppWebsocket implements AppClient {
    */
   static async connect(options: AppWebsocketConnectionOptions = {}) {
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
-    const env = getLauncherEnvironment();
+    const env = await launcherEnv();
 
     if (env?.APP_INTERFACE_PORT) {
       options.url = new URL(`ws://localhost:${env.APP_INTERFACE_PORT}`);

--- a/src/environments/launcher.ts
+++ b/src/environments/launcher.ts
@@ -37,12 +37,14 @@ const getLauncherEnvironment = (): LauncherEnvironment | undefined =>
 export const getHostZomeCallSigner = (): HostZomeCallSigner | undefined =>
   globalThis.window && globalThis.window[__HC_ZOME_CALL_SIGNER__];
 
-export const launcherEnv = async (): Promise<LauncherEnvironment | undefined> => {
+export const launcherEnv = async (): Promise<
+  LauncherEnvironment | undefined
+> => {
   let launcherEnv = getLauncherEnvironment();
-  if(launcherEnv !== undefined) return launcherEnv;
+  if (launcherEnv !== undefined) return launcherEnv;
 
   const awaitLauncherEnv = getAwaitLauncherEnv();
-  if(awaitLauncherEnv !== undefined) {
+  if (awaitLauncherEnv !== undefined) {
     const interval = awaitLauncherEnv.interval || 10;
     const timeout = awaitLauncherEnv.timeout || 5000;
 
@@ -50,7 +52,7 @@ export const launcherEnv = async (): Promise<LauncherEnvironment | undefined> =>
       let elapsed = 0;
       const i = setInterval(() => {
         elapsed += interval;
-        if(elapsed >= timeout) {
+        if (elapsed >= timeout) {
           clearInterval(i);
           resolve();
         }
@@ -65,7 +67,7 @@ export const launcherEnv = async (): Promise<LauncherEnvironment | undefined> =>
 
     return launcherEnv;
   }
-}
+};
 
 declare global {
   interface Window {

--- a/test/e2e/common.ts
+++ b/test/e2e/common.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { Test } from "tape";
-import { AdminWebsocket, CellId, CellType, InstalledAppId, IssueAppAuthenticationTokenResponse } from "../../src";
+import {
+  AdminWebsocket,
+  CellId,
+  CellType,
+  InstalledAppId,
+  IssueAppAuthenticationTokenResponse,
+} from "../../src";
 import { AppWebsocket, CoordinatorBundle } from "../../src";
 import fs from "fs";
 
@@ -144,13 +150,13 @@ export const installAppAndDna = async (
   return { installed_app_id, cell_id, client, admin };
 };
 
-export const createAppInterfaceAndInstallApp =  async (
+export const createAppInterfaceAndInstallApp = async (
   adminPort: number
 ): Promise<{
   installed_app_id: InstalledAppId;
   cell_id: CellId;
   appPort: number;
-  appAuthentication: IssueAppAuthenticationTokenResponse
+  appAuthentication: IssueAppAuthenticationTokenResponse;
   admin: AdminWebsocket;
 }> => {
   const role_name = "foo";
@@ -189,7 +195,8 @@ export const createAppWsAndInstallApp = async (
   client: AppWebsocket;
   admin: AdminWebsocket;
 }> => {
-  const { installed_app_id, cell_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(adminPort);
+  const { installed_app_id, cell_id, appPort, appAuthentication, admin } =
+    await createAppInterfaceAndInstallApp(adminPort);
   const client = await AppWebsocket.connect({
     url: new URL(`ws://localhost:${appPort}`),
     wsClientOptions: { origin: "client-test-app" },
@@ -221,4 +228,5 @@ export async function makeCoordinatorZomeBundle(): Promise<CoordinatorBundle> {
   };
 }
 
-export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/e2e/common.ts
+++ b/test/e2e/common.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { Test } from "tape";
-import { AdminWebsocket, CellId, CellType, InstalledAppId } from "../../src";
+import { AdminWebsocket, CellId, CellType, InstalledAppId, IssueAppAuthenticationTokenResponse } from "../../src";
 import { AppWebsocket, CoordinatorBundle } from "../../src";
 import fs from "fs";
 
@@ -144,12 +144,13 @@ export const installAppAndDna = async (
   return { installed_app_id, cell_id, client, admin };
 };
 
-export const createAppWsAndInstallApp = async (
+export const createAppInterfaceAndInstallApp =  async (
   adminPort: number
 ): Promise<{
   installed_app_id: InstalledAppId;
   cell_id: CellId;
-  client: AppWebsocket;
+  appPort: number;
+  appAuthentication: IssueAppAuthenticationTokenResponse
   admin: AdminWebsocket;
 }> => {
   const role_name = "foo";
@@ -174,14 +175,26 @@ export const createAppWsAndInstallApp = async (
   const { port: appPort } = await admin.attachAppInterface({
     allowed_origins: "client-test-app",
   });
-  const issued = await admin.issueAppAuthenticationToken({
+  const appAuthentication = await admin.issueAppAuthenticationToken({
     installed_app_id,
   });
+  return { installed_app_id, cell_id, appPort, appAuthentication, admin };
+};
+
+export const createAppWsAndInstallApp = async (
+  adminPort: number
+): Promise<{
+  installed_app_id: InstalledAppId;
+  cell_id: CellId;
+  client: AppWebsocket;
+  admin: AdminWebsocket;
+}> => {
+  const { installed_app_id, cell_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(adminPort);
   const client = await AppWebsocket.connect({
     url: new URL(`ws://localhost:${appPort}`),
     wsClientOptions: { origin: "client-test-app" },
     defaultTimeout: 12000,
-    token: issued.token,
+    token: appAuthentication.token,
   });
   return { installed_app_id, cell_id, client, admin };
 };
@@ -207,3 +220,5 @@ export async function makeCoordinatorZomeBundle(): Promise<CoordinatorBundle> {
     },
   };
 }
+
+export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -46,7 +46,6 @@ import {
   delay,
 } from "./common.js";
 
-
 const fakeAgentPubKey = () =>
   Buffer.from(
     [0x84, 0x20, 0x24].concat(

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -43,9 +43,9 @@ import {
   launch,
   makeCoordinatorZomeBundle,
   withConductor,
+  delay,
 } from "./common.js";
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const fakeAgentPubKey = () =>
   Buffer.from(

--- a/test/e2e/launcher.ts
+++ b/test/e2e/launcher.ts
@@ -1,0 +1,154 @@
+import test from "tape";
+import {
+  AdminWebsocket,
+  AppWebsocket,
+  RoleName,
+} from "../../src/index.js";
+import {
+    withConductor,
+    createAppInterfaceAndInstallApp,
+    delay,
+} from "./common.js";
+import { AwaitLauncherEnvironment, HostZomeCallSigner, LauncherEnvironment } from "../../src/environments/launcher.js";
+
+const ADMIN_PORT = 33001;
+
+const ROLE_NAME: RoleName = "foo";
+const TEST_ZOME_NAME = "foo";
+
+
+test(
+  "AdminWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
+  withConductor(ADMIN_PORT, async (t) => {
+    // @ts-ignore-next-line
+    globalThis.window = { Blob };
+    globalThis.window.__HC_LAUNCHER_ENV__ = {
+        ADMIN_INTERFACE_PORT: ADMIN_PORT
+    };
+    const admin = await AdminWebsocket.connect({
+        wsClientOptions: { origin: "client-test-admin" },
+    });
+
+    t.equal(admin.client.url?.href, `ws://localhost:${ADMIN_PORT}/`);
+}));
+
+test(
+    "AppWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
+    withConductor(ADMIN_PORT, async (t) => {
+        // @ts-ignore-next-line
+        globalThis.window = { Blob };
+        
+        const { installed_app_id, cell_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
+
+        globalThis.window.__HC_LAUNCHER_ENV__ = {
+          APP_INTERFACE_PORT: appPort,
+          INSTALLED_APP_ID: installed_app_id,
+          APP_INTERFACE_TOKEN: appAuthentication.token,
+        };
+        const appWs = await AppWebsocket.connect({
+            wsClientOptions: { origin: "client-test-app" },
+        });
+
+        await appWs.networkInfo({
+            dnas: [cell_id[0]],
+        });
+    
+        t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
+}));
+
+
+test(
+    "AdminWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
+    withConductor(ADMIN_PORT, async (t) => {
+        // @ts-ignore-next-line
+        globalThis.window = { Blob };
+        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+            timeout: 10000
+        };
+
+        // Wait 100ms, then set __HC_LAUNCHER_ENV__
+        setTimeout(() => {
+            globalThis.window.__HC_LAUNCHER_ENV__ = {
+                ADMIN_INTERFACE_PORT: ADMIN_PORT
+            };
+        }, 100);
+
+        // Immediately attempt to connect to AdminWebsocket
+        const admin = await AdminWebsocket.connect({
+            wsClientOptions: { origin: "client-test-admin" },
+        });
+
+        // Wait 200ms
+        await delay(200);
+
+        // Assert we have received the __HC_LAUNCHER_ENV__
+        t.equal(admin.client.url?.href, `ws://localhost:${ADMIN_PORT}/`);
+  }));
+
+
+
+  test(
+    "AppWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
+    withConductor(ADMIN_PORT, async (t) => {
+        // @ts-ignore-next-line
+        globalThis.window = { Blob };
+    
+        const { installed_app_id, appPort, appAuthentication } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
+
+        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+            timeout: 10000
+        };
+        
+        // Wait 100ms, then set __HC_LAUNCHER_ENV__
+        setTimeout(() => {
+            globalThis.window.__HC_LAUNCHER_ENV__ = {
+                APP_INTERFACE_PORT: appPort,
+                INSTALLED_APP_ID: installed_app_id,
+                APP_INTERFACE_TOKEN: appAuthentication.token,
+            };
+        }, 100);
+
+        // Immediately attempt to connect to AppWebsocket
+        const appWs = await AppWebsocket.connect({
+            wsClientOptions: { origin: "client-test-app" },
+        });
+
+        // Wait 200ms
+        await delay(200);
+
+        // Assert we have received the __HC_LAUNCHER_ENV__
+        t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
+}));
+
+
+test(
+    "AppWebsocket does not wait for window.__HC_AWAIT_LAUNCHER_ENV__ past timeout",
+    withConductor(ADMIN_PORT, async (t) => {
+        // @ts-ignore-next-line
+        globalThis.window = { Blob };
+        
+        const { installed_app_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
+        
+        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+            interval: 10,
+            timeout: 100
+        };
+
+
+        setTimeout(() => {
+            globalThis.window.__HC_LAUNCHER_ENV__ = {
+                APP_INTERFACE_PORT: appPort,
+                INSTALLED_APP_ID: installed_app_id,
+                APP_INTERFACE_TOKEN: appAuthentication.token,
+            };
+        }, 200)
+
+          try {
+            await AppWebsocket.connect({
+                wsClientOptions: { origin: "client-test-app" },
+            });
+            t.fail();
+          } catch(e) {
+            t.pass();
+          }
+    }));

--- a/test/e2e/launcher.ts
+++ b/test/e2e/launcher.ts
@@ -1,154 +1,153 @@
 import test from "tape";
+import { AdminWebsocket, AppWebsocket } from "../../src/index.js";
 import {
-  AdminWebsocket,
-  AppWebsocket,
-  RoleName,
-} from "../../src/index.js";
-import {
-    withConductor,
-    createAppInterfaceAndInstallApp,
-    delay,
+  withConductor,
+  createAppInterfaceAndInstallApp,
+  delay,
 } from "./common.js";
-import { AwaitLauncherEnvironment, HostZomeCallSigner, LauncherEnvironment } from "../../src/environments/launcher.js";
 
 const ADMIN_PORT = 33001;
-
-const ROLE_NAME: RoleName = "foo";
-const TEST_ZOME_NAME = "foo";
-
 
 test(
   "AdminWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
   withConductor(ADMIN_PORT, async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore-next-line
     globalThis.window = { Blob };
     globalThis.window.__HC_LAUNCHER_ENV__ = {
-        ADMIN_INTERFACE_PORT: ADMIN_PORT
+      ADMIN_INTERFACE_PORT: ADMIN_PORT,
     };
     const admin = await AdminWebsocket.connect({
-        wsClientOptions: { origin: "client-test-admin" },
+      wsClientOptions: { origin: "client-test-admin" },
     });
 
     t.equal(admin.client.url?.href, `ws://localhost:${ADMIN_PORT}/`);
-}));
+  })
+);
 
 test(
-    "AppWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
-    withConductor(ADMIN_PORT, async (t) => {
-        // @ts-ignore-next-line
-        globalThis.window = { Blob };
-        
-        const { installed_app_id, cell_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
+  "AppWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
+  withConductor(ADMIN_PORT, async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line
+    globalThis.window = { Blob };
 
-        globalThis.window.__HC_LAUNCHER_ENV__ = {
-          APP_INTERFACE_PORT: appPort,
-          INSTALLED_APP_ID: installed_app_id,
-          APP_INTERFACE_TOKEN: appAuthentication.token,
-        };
-        const appWs = await AppWebsocket.connect({
-            wsClientOptions: { origin: "client-test-app" },
-        });
+    const { installed_app_id, cell_id, appPort, appAuthentication } =
+      await createAppInterfaceAndInstallApp(ADMIN_PORT);
 
-        await appWs.networkInfo({
-            dnas: [cell_id[0]],
-        });
-    
-        t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
-}));
+    globalThis.window.__HC_LAUNCHER_ENV__ = {
+      APP_INTERFACE_PORT: appPort,
+      INSTALLED_APP_ID: installed_app_id,
+      APP_INTERFACE_TOKEN: appAuthentication.token,
+    };
+    const appWs = await AppWebsocket.connect({
+      wsClientOptions: { origin: "client-test-app" },
+    });
 
+    await appWs.networkInfo({
+      dnas: [cell_id[0]],
+    });
 
-test(
-    "AdminWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
-    withConductor(ADMIN_PORT, async (t) => {
-        // @ts-ignore-next-line
-        globalThis.window = { Blob };
-        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
-            timeout: 10000
-        };
-
-        // Wait 100ms, then set __HC_LAUNCHER_ENV__
-        setTimeout(() => {
-            globalThis.window.__HC_LAUNCHER_ENV__ = {
-                ADMIN_INTERFACE_PORT: ADMIN_PORT
-            };
-        }, 100);
-
-        // Immediately attempt to connect to AdminWebsocket
-        const admin = await AdminWebsocket.connect({
-            wsClientOptions: { origin: "client-test-admin" },
-        });
-
-        // Wait 200ms
-        await delay(200);
-
-        // Assert we have received the __HC_LAUNCHER_ENV__
-        t.equal(admin.client.url?.href, `ws://localhost:${ADMIN_PORT}/`);
-  }));
-
-
-
-  test(
-    "AppWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
-    withConductor(ADMIN_PORT, async (t) => {
-        // @ts-ignore-next-line
-        globalThis.window = { Blob };
-    
-        const { installed_app_id, appPort, appAuthentication } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
-
-        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
-            timeout: 10000
-        };
-        
-        // Wait 100ms, then set __HC_LAUNCHER_ENV__
-        setTimeout(() => {
-            globalThis.window.__HC_LAUNCHER_ENV__ = {
-                APP_INTERFACE_PORT: appPort,
-                INSTALLED_APP_ID: installed_app_id,
-                APP_INTERFACE_TOKEN: appAuthentication.token,
-            };
-        }, 100);
-
-        // Immediately attempt to connect to AppWebsocket
-        const appWs = await AppWebsocket.connect({
-            wsClientOptions: { origin: "client-test-app" },
-        });
-
-        // Wait 200ms
-        await delay(200);
-
-        // Assert we have received the __HC_LAUNCHER_ENV__
-        t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
-}));
-
+    t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
+  })
+);
 
 test(
-    "AppWebsocket does not wait for window.__HC_AWAIT_LAUNCHER_ENV__ past timeout",
-    withConductor(ADMIN_PORT, async (t) => {
-        // @ts-ignore-next-line
-        globalThis.window = { Blob };
-        
-        const { installed_app_id, appPort, appAuthentication, admin } = await createAppInterfaceAndInstallApp(ADMIN_PORT);
-        
-        globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
-            interval: 10,
-            timeout: 100
-        };
+  "AdminWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
+  withConductor(ADMIN_PORT, async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line
+    globalThis.window = { Blob };
+    globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+      timeout: 10000,
+    };
 
+    // Wait 100ms, then set __HC_LAUNCHER_ENV__
+    setTimeout(() => {
+      globalThis.window.__HC_LAUNCHER_ENV__ = {
+        ADMIN_INTERFACE_PORT: ADMIN_PORT,
+      };
+    }, 100);
 
-        setTimeout(() => {
-            globalThis.window.__HC_LAUNCHER_ENV__ = {
-                APP_INTERFACE_PORT: appPort,
-                INSTALLED_APP_ID: installed_app_id,
-                APP_INTERFACE_TOKEN: appAuthentication.token,
-            };
-        }, 200)
+    // Immediately attempt to connect to AdminWebsocket
+    const admin = await AdminWebsocket.connect({
+      wsClientOptions: { origin: "client-test-admin" },
+    });
 
-          try {
-            await AppWebsocket.connect({
-                wsClientOptions: { origin: "client-test-app" },
-            });
-            t.fail();
-          } catch(e) {
-            t.pass();
-          }
-    }));
+    // Wait 200ms
+    await delay(200);
+
+    // Assert we have received the __HC_LAUNCHER_ENV__
+    t.equal(admin.client.url?.href, `ws://localhost:${ADMIN_PORT}/`);
+  })
+);
+
+test(
+  "AppWebsocket waits for window.__HC_LAUNCHER_ENV__ when window.__HC_AWAIT_LAUNCHER_ENV__ is defined",
+  withConductor(ADMIN_PORT, async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line
+    globalThis.window = { Blob };
+
+    const { installed_app_id, appPort, appAuthentication } =
+      await createAppInterfaceAndInstallApp(ADMIN_PORT);
+
+    globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+      timeout: 10000,
+    };
+
+    // Wait 100ms, then set __HC_LAUNCHER_ENV__
+    setTimeout(() => {
+      globalThis.window.__HC_LAUNCHER_ENV__ = {
+        APP_INTERFACE_PORT: appPort,
+        INSTALLED_APP_ID: installed_app_id,
+        APP_INTERFACE_TOKEN: appAuthentication.token,
+      };
+    }, 100);
+
+    // Immediately attempt to connect to AppWebsocket
+    const appWs = await AppWebsocket.connect({
+      wsClientOptions: { origin: "client-test-app" },
+    });
+
+    // Wait 200ms
+    await delay(200);
+
+    // Assert we have received the __HC_LAUNCHER_ENV__
+    t.equal(appWs.client.url?.href, `ws://localhost:${appPort}/`);
+  })
+);
+
+test(
+  "AppWebsocket does not wait for window.__HC_AWAIT_LAUNCHER_ENV__ past timeout",
+  withConductor(ADMIN_PORT, async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line
+    globalThis.window = { Blob };
+
+    const { installed_app_id, appPort, appAuthentication } =
+      await createAppInterfaceAndInstallApp(ADMIN_PORT);
+
+    globalThis.window.__HC_AWAIT_LAUNCHER_ENV__ = {
+      interval: 10,
+      timeout: 100,
+    };
+
+    setTimeout(() => {
+      globalThis.window.__HC_LAUNCHER_ENV__ = {
+        APP_INTERFACE_PORT: appPort,
+        INSTALLED_APP_ID: installed_app_id,
+        APP_INTERFACE_TOKEN: appAuthentication.token,
+      };
+    }, 200);
+
+    try {
+      await AppWebsocket.connect({
+        wsClientOptions: { origin: "client-test-app" },
+      });
+      t.fail();
+    } catch (e) {
+      t.pass();
+    }
+  })
+);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,4 @@
 import "./e2e/index.js";
 import "./e2e/app-websocket";
 import "./e2e/utils.js";
+import "./e2e/launcher";


### PR DESCRIPTION
### Summary
I have an issue without a perfect solution: https://github.com/holochain/android-service-runtime/issues/74 I believe this PR is least-worst option. 

This PR adds another magic variable `window.__HC_AWAIT_LAUNCHER_ENV__`. If this variable is defined, then the client will poll for `window.__HC_LAUNCHER_ENV__` until the specified timeout. 

This allows `window.__HC_LAUNCHER_ENV__` to be defined shortly after `.connect()` is called.

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`) (no changes)
