### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 ### Removed
 
+
+## 2025-04-22: v0.19.0
+
 ## 2025-04-18: v0.19.0-rc.1
 ### Added
 - Tests for magic config variables: `window.__HC_LAUNCHER_ENV__` and `window.__HC_ZOME_CALL_SIGNER__`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.19.0-rc.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.19.0-rc.1",
+      "version": "0.19.0",
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.19.0-rc.1",
+  "version": "0.19.0",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",


### PR DESCRIPTION
### Summary
Release 0.19.0

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)
