### PR TITLE
Fixed sha512 import

### DIFF
--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from "@msgpack/msgpack";
 import Emittery, { UnsubscribeFunction } from "emittery";
-import { sha512 } from "js-sha512";
+import sha512 from "js-sha512";
 import _sodium from "libsodium-wrappers";
 import { omit } from "lodash-es";
 import {


### PR DESCRIPTION
### Summary

I have the following error with the latest holochain-client-js:
`Uncaught SyntaxError: The requested module './../../../../../../../../js-sha512/src/sha512.js' does not provide an export named 'sha512' (at websocket.js:3:10)`

This PR fixes the error.

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)
