### PR TITLE
fix: Typing of `DhtArc` is wrong

### DIFF
--- a/docs/client.dhtarc.md
+++ b/docs/client.dhtarc.md
@@ -9,10 +9,13 @@ The definition of a storage arc compatible with the concept of storage and query
 **Signature:**
 
 ```typescript
-export type DhtArc = {
-    type: "empty";
-} | {
-    type: "arc";
-    value: [number, number];
-};
+export type DhtArc = /**
+ * No DHT locations are contained within this arc.
+ */ null
+/**
+ * A specific range of DHT locations are contained within this arc.
+ *
+ * The lower and upper bounds are inclusive.
+ */
+ | [number, number];
 ```

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -1068,22 +1068,16 @@ export interface DumpNetworkMetricsRequest {
  * @public
  */
 export type DhtArc =
-  | {
-      /**
-       * No DHT locations are contained within this arc.
-       */
-      type: "empty";
-    }
-  | {
-      /**
-       * A specific range of DHT locations are contained within this arc.
-       *
-       * The lower and upper bounds are inclusive.
-       */
-      type: "arc";
-      value: [number, number];
-    };
-
+  | /**
+   * No DHT locations are contained within this arc.
+   */
+  null
+  /**
+   * A specific range of DHT locations are contained within this arc.
+   *
+   * The lower and upper bounds are inclusive.
+   */
+  | [number, number];
 /**
  * Summary of a local agent's network state.
  *

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -1068,7 +1068,8 @@ export interface DumpNetworkMetricsRequest {
  * @public
  */
 export type DhtArc =
-  | /**
+  |
+  /**
    * No DHT locations are contained within this arc.
    */
   null


### PR DESCRIPTION
### Summary

This should be backported to the previous client version too

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)
