### PR TITLE
backport 0.5 (fix): make WsClientOptions undefined by default due to lacking browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `AgentMetaInfo` calls to the conductor's app and admin interfaces to retrieve info about peers from the peer meta store.
 ### Fixed
 - Tests of examples in README didn't return error exit codes. A breaking change went unnoticed. Tests now return error code and examples are up-to-date.
+- Fixed the logic to reconnect the AppWebsocket automatically in the browser ([#354](https://github.com/holochain/holochain-client-js/pull/354))
 ### Changed
 - Run all tests with local bootstrap and signaling services.
 ### Removed

--- a/docs/client.wsclient.md
+++ b/docs/client.wsclient.md
@@ -82,7 +82,7 @@ Description
 
 </td><td>
 
-[WsClientOptions](./client.wsclientoptions.md)
+[WsClientOptions](./client.wsclientoptions.md) \| undefined
 
 
 </td><td>

--- a/docs/client.wsclient.options.md
+++ b/docs/client.wsclient.options.md
@@ -7,5 +7,5 @@
 **Signature:**
 
 ```typescript
-options: WsClientOptions;
+options: WsClientOptions | undefined;
 ```

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,7 +38,7 @@ export interface AppAuthenticationRequest {
 export class WsClient extends Emittery {
   socket: IsoWebSocket;
   url: URL | undefined;
-  options: WsClientOptions;
+  options: WsClientOptions | undefined;
   private pendingRequests: Record<number, HolochainRequest>;
   private index: number;
   private authenticationToken: AppAuthenticationToken | undefined;
@@ -49,7 +49,7 @@ export class WsClient extends Emittery {
     this.registerCloseListener(socket);
     this.socket = socket;
     this.url = url;
-    this.options = options || {};
+    this.options = options;
     this.pendingRequests = {};
     this.index = 0;
   }


### PR DESCRIPTION
### Summary

Backport of #354 

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)
