### PR TITLE
fix: expires_at field in PeerMetaInfo type can be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `expires_at` field in `PeerMetaInfo` type to allow it being `undefined` ([#368](https://github.com/holochain/holochain-client-js/pull/368))
 - Fixed types for `list_apps` to match the new API
 
 ### Changed

--- a/docs/client.peermetainfo.expires_at.md
+++ b/docs/client.peermetainfo.expires_at.md
@@ -7,5 +7,5 @@
 **Signature:**
 
 ```typescript
-expires_at: Timestamp;
+expires_at: Timestamp | null;
 ```

--- a/docs/client.peermetainfo.md
+++ b/docs/client.peermetainfo.md
@@ -44,7 +44,7 @@ Description
 
 </td><td>
 
-[Timestamp](./client.timestamp.md)
+[Timestamp](./client.timestamp.md) \| null
 
 
 </td><td>

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -646,7 +646,7 @@ export type PeerMetaInfoResponse = Record<
  */
 export interface PeerMetaInfo {
   meta_value: string;
-  expires_at: Timestamp;
+  expires_at: Timestamp | null;
 }
 
 /**


### PR DESCRIPTION
### Summary

As mentioned in [this PR comment](https://github.com/holochain/holochain-client-js/pull/364#discussion_r2248170088) and fixed in holochain with https://github.com/holochain/holochain/pull/5183, the `PeerMetaInfo` type's `expires_at` field can be undefined.

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that the `expires_at` field in `PeerMetaInfo` can now be null, improving accuracy in documentation and type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->