### PR TITLE
Update UpdateCoordinatorsRequest and GetDnaDefinitionReque…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **BREAKING**: `GetDnaDefinitionRequest` now takes a `CellId` as argument instead of a `DnaHash` ([#369](https://github.com/holochain/holochain-client-js/pull/369))
+- **BREAKING**: `UpdateCoordinatorsRequest` now takes a `CellId` as argument instead of a `DnaHash` ([#369](https://github.com/holochain/holochain-client-js/pull/369))
 - Updated hc sandbox command used in internal tests according to changes introduced with holochain 0.6.0-dev.16 ([#370](https://github.com/holochain/holochain-client-js/pull/370))
 - **BREAKING**: Renamed `AgentMetaInfo` to `PeerMetaInfo` ([#364](https://github.com/holochain/holochain-client-js/pull/364))
 - Changed return type of `grantZomeCallCapability` to `ActionHash` [#360](https://github.com/holochain/holochain-client-js/pull/360)

--- a/docs/client.getdnadefinitionrequest.md
+++ b/docs/client.getdnadefinitionrequest.md
@@ -8,7 +8,7 @@
 **Signature:**
 
 ```typescript
-export type GetDnaDefinitionRequest = DnaHash;
+export type GetDnaDefinitionRequest = CellId;
 ```
-**References:** [DnaHash](./client.dnahash.md)
+**References:** [CellId](./client.cellid.md)
 

--- a/docs/client.updatecoordinatorsrequest.md
+++ b/docs/client.updatecoordinatorsrequest.md
@@ -10,8 +10,8 @@
 ```typescript
 export type UpdateCoordinatorsRequest = {
     source: CoordinatorSource;
-    dna_hash: DnaHash;
+    cell_id: CellId;
 };
 ```
-**References:** [CoordinatorSource](./client.coordinatorsource.md)<!-- -->, [DnaHash](./client.dnahash.md)
+**References:** [CoordinatorSource](./client.coordinatorsource.md)<!-- -->, [CellId](./client.cellid.md)
 

--- a/flake.lock
+++ b/flake.lock
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1753835376,
-        "narHash": "sha256-CxkVsc9fEieBjJNIzp0zD/tACvoe5F0BI9SZvPGPmBc=",
+        "lastModified": 1755045022,
+        "narHash": "sha256-Zx6PvpIaVAUawYeu2Nq01dahvLNOkfyvkcXoNCQNYWg=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "fdef8f10bdc53bd9dd230d38510ee259a8a8bad2",
+        "rev": "803cd5a59902da1d079c52150eb01eb5db0e1a71",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0-dev.15",
+        "ref": "holochain-0.6.0-dev.17",
         "repo": "holochain",
         "type": "github"
       }
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1753867932,
-        "narHash": "sha256-9l71IZAimVIwX73QXwOiSBm/93/RZeCnTqfz95pazPE=",
+        "lastModified": 1755207430,
+        "narHash": "sha256-KEndOQv39opJlifgbV8k05W3paDxesVqNfqcVy34w/k=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "04e365cbb99da4cdd29811e76ed4914b18934db7",
+        "rev": "8a29e6f9c01bfe6696f0f230bd423b5d567a0871",
         "type": "github"
       },
       "original": {

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -304,7 +304,7 @@ export type DnaDefinition = {
 /**
  * @public
  */
-export type GetDnaDefinitionRequest = DnaHash;
+export type GetDnaDefinitionRequest = CellId;
 /**
  * @public
  */
@@ -326,7 +326,7 @@ export type UninstallAppResponse = null;
  */
 export type UpdateCoordinatorsRequest = {
   source: CoordinatorSource;
-  dna_hash: DnaHash;
+  cell_id: CellId;
 };
 
 /**

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -1457,14 +1457,14 @@ test(
     const bundle = await makeCoordinatorZomeBundle();
 
     await admin.updateCoordinators({
-      dna_hash: cell_id[0],
+      cell_id,
       source: {
         type: "bundle",
         value: bundle,
       },
     });
 
-    const dnaDef = await admin.getDnaDefinition(cell_id[0]);
+    const dnaDef = await admin.getDnaDefinition(cell_id);
     const zomeNames = dnaDef.coordinator_zomes.map((x) => x[0]);
 
     t.ok(


### PR DESCRIPTION
### Summary

Update types to follow chages introduced with https://github.com/holochain/holochain/pull/5189

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Admin API requests now require a CellId instead of a DnaHash for fetching DNA definitions and updating coordinators; update client integrations.

- Documentation
  - Reference docs updated to reflect CellId usage for the affected requests.

- Tests
  - End-to-end tests updated to use CellId; sandbox startup logging and stdout parsing improved for more reliable initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->