### PR TITLE
fix: update hc sandbox command used by tests to changes introduced in holochain 0.6.0-dev.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updated hc sandbox command used in internal tests according to changes introduced with holochain 0.6.0-dev.16 ([#370](https://github.com/holochain/holochain-client-js/pull/370))
 - **BREAKING**: Renamed `AgentMetaInfo` to `PeerMetaInfo` ([#364](https://github.com/holochain/holochain-client-js/pull/364))
 - Changed return type of `grantZomeCallCapability` to `ActionHash` [#360](https://github.com/holochain/holochain-client-js/pull/360)
 

--- a/test/e2e/common.ts
+++ b/test/e2e/common.ts
@@ -102,10 +102,22 @@ export const launch = async (
   });
   await createConductorPromise;
 
+  // Find out the conductor index of the created conductor
+  const dotHcFileContentLines = fs
+    .readFileSync(".hc", "utf-8")
+    .split(/\r?\n/)
+    .map((l) => l.trim());
+  const conductorIndex = dotHcFileContentLines.findIndex(
+    (line) => line === conductorDir
+  );
+
+  if (conductorIndex === -1)
+    throw new Error("Failed to determine index of recently started conductor.");
+
   // start sandbox conductor
   const runConductorProcess = spawn(
     "hc",
-    ["sandbox", "--piped", `-f=${port}`, "run", "-e", conductorDir],
+    ["sandbox", "--piped", `-f=${port}`, "run", `${conductorIndex}`],
     {
       detached: true, // create a process group; without this option, killing
       // the process doesn't kill the conductor


### PR DESCRIPTION
### Summary
The `-e` option in `hc sandbox run` has been removed with https://github.com/holochain/holochain/pull/5173. This PR updates the command accordingly.

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changelog updated to note internal test sandbox alignment with Holochain 0.6.0-dev.16; documentation-only, no code/API/runtime changes.

* **Tests**
  * End-to-end tests updated to select the target conductor by index for sandbox runs.
  * Added error handling when the conductor index cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->