### PR TITLE
chore(release): v0.20.0-dev.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 ### Added
+### Fixed
+### Changed
+### Removed
 
+## 2025-09-04: v0.20.0-dev.2
+### Added
 - Added `revokeZomeCallCapability` to the admin websocket to revoke zome call capabilities for an agent [#360](https://github.com/holochain/holochain-client-js/pull/360)
 - Added `listCapabilityGrants` to the admin websocket to list all zome call capabilities granted to an agent [#360](https://github.com/holochain/holochain-client-js/pull/360)
-
 ### Fixed
-
 - Fixed `dna_hash` field in `DumpNetworkMetricsRequest` type ([#371](https://github.com/holochain/holochain-client-js/pull/371))
 - Fixed `expires_at` field in `PeerMetaInfo` type to allow it being `undefined` ([#368](https://github.com/holochain/holochain-client-js/pull/368))
 - Fixed types for `list_apps` to match the new API
-
 ### Changed
-
 - **BREAKING**: `GetDnaDefinitionRequest` now takes a `CellId` as argument instead of a `DnaHash` ([#369](https://github.com/holochain/holochain-client-js/pull/369))
 - **BREAKING**: `UpdateCoordinatorsRequest` now takes a `CellId` as argument instead of a `DnaHash` ([#369](https://github.com/holochain/holochain-client-js/pull/369))
 - Updated hc sandbox command used in internal tests according to changes introduced with holochain 0.6.0-dev.16 ([#370](https://github.com/holochain/holochain-client-js/pull/370))
 - **BREAKING**: Renamed `AgentMetaInfo` to `PeerMetaInfo` ([#364](https://github.com/holochain/holochain-client-js/pull/364))
 - Changed return type of `grantZomeCallCapability` to `ActionHash` [#360](https://github.com/holochain/holochain-client-js/pull/360)
-
 ### Removed
-
 - **BREAKING** Removed `RegisterDna` admin call ([#367](https://github.com/holochain/holochain-client-js/pull/367))
 
 ## 2025-07-02: v0.20.0-dev.1

--- a/flake.lock
+++ b/flake.lock
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1755045022,
-        "narHash": "sha256-Zx6PvpIaVAUawYeu2Nq01dahvLNOkfyvkcXoNCQNYWg=",
+        "lastModified": 1756913828,
+        "narHash": "sha256-g6uMmnyvWLauoN56UnRcqp9g6XXsgt6dMq7olp0GrkA=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "803cd5a59902da1d079c52150eb01eb5db0e1a71",
+        "rev": "86affa7aa25eb7e02864d28ff60222351b6ccee4",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0-dev.17",
+        "ref": "holochain-0.6.0-dev.20",
         "repo": "holochain",
         "type": "github"
       }
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755207430,
-        "narHash": "sha256-KEndOQv39opJlifgbV8k05W3paDxesVqNfqcVy34w/k=",
+        "lastModified": 1756927627,
+        "narHash": "sha256-InyCu7VmnrDuFc920nZpMfNKPm+Kz6Lu5CpsX+ks/Ew=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "8a29e6f9c01bfe6696f0f230bd423b5d567a0871",
+        "rev": "4747d05952043702ef59d01372c6807224e4143e",
         "type": "github"
       },
       "original": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.0-dev.1",
+  "version": "0.20.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.20.0-dev.1",
+      "version": "0.20.0-dev.2",
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.0-dev.1",
+  "version": "0.20.0-dev.2",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",


### PR DESCRIPTION
### Summary

Release 0.20.0-dev.2

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the changelog to include top-level sections (Added, Fixed, Changed, Removed).
  * Added a new entry for v0.20.0-dev.2 highlighting two admin websocket capabilities: revokeZomeCallCapability and listCapabilityGrants.
  * Removed previously listed Fixed/Changed/Removed subsections under this release.

* **Chores**
  * Bumped version to 0.20.0-dev.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->