### PR TITLE
style: set fixed value 0 for manifest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Fixed
 ### Changed
+- **BREAKING**: Set "0" as the only possible value for `manifest_version` in types `DnaManifest` and `AppManifest`. (#375)
 ### Removed
 
 ## 2025-09-04: v0.20.0-dev.2

--- a/docs/client.appmanifest.md
+++ b/docs/client.appmanifest.md
@@ -9,7 +9,7 @@
 
 ```typescript
 export type AppManifest = {
-    manifest_version: string;
+    manifest_version: "0";
     name: string;
     description?: string;
     roles: Array<AppRoleManifest>;

--- a/docs/client.dnamanifest.md
+++ b/docs/client.dnamanifest.md
@@ -9,7 +9,7 @@
 
 ```typescript
 export type DnaManifest = {
-    manifest_version: string;
+    manifest_version: "0";
     name: string;
     network_seed?: NetworkSeed;
     properties?: DnaProperties;

--- a/src/api/admin/types.ts
+++ b/src/api/admin/types.ts
@@ -440,8 +440,7 @@ export type AppRoleManifest = {
  * @public
  */
 export type AppManifest = {
-  // Currently "1" is supported
-  manifest_version: string;
+  manifest_version: "0";
 
   name: string;
   description?: string;
@@ -811,9 +810,9 @@ export type CoordinatorSource =
  */
 export type DnaManifest = {
   /**
-   * Currently one "1" is supported
+   * No finalized version yet, hence only "0" is supported.
    */
-  manifest_version: string;
+  manifest_version: "0";
 
   /**
    * The friendly "name" of a Holochain DNA.


### PR DESCRIPTION
### Summary


### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * manifest_version in AppManifest and DnaManifest is now restricted to the literal "0" — breaking change: manifests must use "0" exclusively.

* **Documentation**
  * Updated AppManifest and DnaManifest docs to reflect the new manifest_version constraint and current supported value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->