### PR TITLE
chore: Bump package version to 0.21.0-dev.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.0-rc.0",
+  "version": "0.21.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.20.0-rc.0",
+      "version": "0.21.0-dev.0",
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.0",
+  "version": "0.21.0-dev.0",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",


### PR DESCRIPTION
### Summary

To ensure that we don't accidentally publish 0.20.x releases from the main branch.

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to development release (0.21.0-dev.0)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->