### PR TITLE
fix: bump libsodium to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2026-01-08: v0.20.2
 
-### Added
 ### Fixed
 - Bump `libsodium` to `0.8` to fix `libsodium.mjs` resolution
-### Changed
-### Removed
 
 ## 2025-12-04: v0.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 ### Removed
 
+## 2026-01-08: v0.20.2
+
+### Added
+### Fixed
+- Bump `libsodium` to `0.8` to fix `libsodium.mjs` resolution
+### Changed
+### Removed
+
 ## 2025-12-04: v0.20.1
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holochain/client",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",
@@ -15,7 +15,7 @@
         "isomorphic-ws": "^5.0.0",
         "js-base64": "^3.7.8",
         "js-sha512": "^0.9.0",
-        "libsodium-wrappers": "^0.7.15",
+        "libsodium-wrappers": "^0.8",
         "lodash-es": "^4.17.21",
         "ws": "^8.18.3"
       },
@@ -3775,18 +3775,18 @@
       }
     },
     "node_modules/libsodium": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
-      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.0.tgz",
+      "integrity": "sha512-GQ4Sg0/Z0Ui6ZvKeTd8bH7VAAqk1ZHZDAo/pcuSi0uPbIN6LYAAotR0GEYb8v+y4/tSsXZPr06D6hhqKd7tnoQ==",
       "license": "ISC"
     },
     "node_modules/libsodium-wrappers": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
-      "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.0.tgz",
+      "integrity": "sha512-PVyXAtP1nmpQrDKAVnA8pir0f7bj7vmMGs7mb+0OCSJ+BOfLNBb5hPy2GHfrx6cQ+Co9fMliR5R0WRbVuMllNA==",
       "license": "ISC",
       "dependencies": {
-        "libsodium": "^0.7.15"
+        "libsodium": "^0.8.0"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/client",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "A JavaScript client for the Holochain Conductor API",
   "author": "Holochain Foundation <info@holochain.org> (https://holochain.org)",
   "license": "CAL-1.0",
@@ -48,7 +48,7 @@
     "isomorphic-ws": "^5.0.0",
     "js-base64": "^3.7.8",
     "js-sha512": "^0.9.0",
-    "libsodium-wrappers": "^0.7.15",
+    "libsodium-wrappers": "^0.8",
     "lodash-es": "^4.17.21",
     "ws": "^8.18.3"
   },


### PR DESCRIPTION
libsodium 0.7.16 doesn't resolve libsodium.mjs

closes #396

### TODO:
- [x] CHANGELOG mentions all code changes.
- [x] docs have been updated (`npm run build:docs`)
