### PR TITLE
test: add 60s timeout to all tests

### DIFF
--- a/test/e2e/app-websocket.ts
+++ b/test/e2e/app-websocket.ts
@@ -30,6 +30,7 @@ const TEST_ZOME_NAME = "foo";
 
 test(
   "can call a zome function and get app info",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const {
       installed_app_id,
@@ -88,6 +89,7 @@ test(
 
 test(
   "can receive a signal",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     let resolveSignalPromise: (value?: unknown) => void | undefined;
     const signalReceivedPromise = new Promise(
@@ -126,6 +128,7 @@ test(
 
 test(
   "cells only receive their own signals",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const role_name = "foo";
     const admin = await AdminWebsocket.connect({
@@ -213,6 +216,7 @@ test(
 
 test(
   "can create a callable clone cell and call it by clone id",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, client: appWs } = await createAppWsAndInstallApp(ADMIN_PORT);
     const info = await appWs.appInfo();
@@ -251,6 +255,7 @@ test(
 
 test(
   "can disable and re-enable a clone cell",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, client: appWs } = await createAppWsAndInstallApp(ADMIN_PORT);
 
@@ -295,6 +300,7 @@ test(
 
 test(
   "can grant and revoke zome call capabilities",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const {
       admin,
@@ -385,6 +391,7 @@ test(
 if (process.env.TEST_UNSTABLE === "true") {
   test(
     "countersigning session interaction calls",
+    { timeout: 60_000 },
     withConductor(ADMIN_PORT, async (t) => {
       const { client: appWs, cell_id } =
         await createAppWsAndInstallApp(ADMIN_PORT);

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -70,6 +70,7 @@ export const ADMIN_WS_URL = new URL(`ws://localhost:${ADMIN_PORT}`);
 
 test(
   "admin smoke test: installApp + uninstallApp",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const installed_app_id = "app";
     const admin = await AdminWebsocket.connect({
@@ -183,6 +184,7 @@ test(
 
 test(
   "admin smoke test: installBundle",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const installed_app_id = "app";
     const admin = await AdminWebsocket.connect({
@@ -253,6 +255,7 @@ test(
 
 test(
   "can call a zome function and then deactivate",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { installed_app_id, cell_id, client, admin } =
       await installAppAndDna(ADMIN_PORT);
@@ -301,6 +304,7 @@ test(
 
 test(
   "can call a zome function with different sets of params",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -336,6 +340,7 @@ test(
 
 test(
   "can call attachAppInterface without specific port",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, installed_app_id } = await installAppAndDna(ADMIN_PORT);
     const { port } = await admin.attachAppInterface({
@@ -356,6 +361,7 @@ test(
 
 test(
   "invalid app authentication token fails",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin } = await installAppAndDna(ADMIN_PORT);
     const { port } = await admin.attachAppInterface({
@@ -378,6 +384,7 @@ test(
 
 test(
   "app websocket connection from allowed origin is established",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, installed_app_id } = await installAppAndDna(ADMIN_PORT);
     const allowedOrigin = "client-test-app";
@@ -402,6 +409,7 @@ test(
 
 test(
   "app websocket connection from disallowed origin is rejected",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, installed_app_id } = await installAppAndDna(ADMIN_PORT);
     const { port } = await admin.attachAppInterface({
@@ -426,6 +434,7 @@ test(
 
 test(
   "client errors are HolochainErrors",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     const info = await client.appInfo(1000);
@@ -458,6 +467,7 @@ test(
 
 test(
   "can install app with roles_settings",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const installed_app_id = "app";
     const admin = await AdminWebsocket.connect({
@@ -503,6 +513,7 @@ test(
 
 test(
   "memproofs can be provided after app installation",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const role_name = "foo";
     const installed_app_id = "app";
@@ -600,6 +611,7 @@ test(
 
 test(
   "generated signing key has same location bytes as original agent pub key",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const admin = await AdminWebsocket.connect({
       url: ADMIN_WS_URL,
@@ -613,6 +625,7 @@ test(
 
 test(
   "install app from bytes",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const role_name = "foo";
     const installed_app_id = "app";
@@ -665,6 +678,7 @@ test(
 
 test(
   "stateDump",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     const info = await client.appInfo();
@@ -696,6 +710,7 @@ test(
 
 test(
   "fullStateDump with ChainOps",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, admin } = await installAppAndDna(ADMIN_PORT);
     const state: FullStateDump = await admin.dumpFullState({
@@ -709,6 +724,7 @@ test(
 
 test(
   "can receive a signal using event handler",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, cell_id, client } = await installAppAndDna(ADMIN_PORT);
     let resolveSignalPromise: (value?: unknown) => void | undefined;
@@ -741,26 +757,31 @@ test(
 );
 
 // test without conductor
-test("error is catchable when holochain socket is unavailable", async (t) => {
-  try {
-    await AdminWebsocket.connect({ url: ADMIN_WS_URL });
-    t.fail("websocket connection should have failed");
-  } catch (e) {
-    t.assert(e instanceof HolochainError, "expected a HolochainError");
-    t.pass("websocket connection failed as expected");
-  }
+test(
+  "error is catchable when holochain socket is unavailable",
+  { timeout: 60_000 },
+  async (t) => {
+    try {
+      await AdminWebsocket.connect({ url: ADMIN_WS_URL });
+      t.fail("websocket connection should have failed");
+    } catch (e) {
+      t.assert(e instanceof HolochainError, "expected a HolochainError");
+      t.pass("websocket connection failed as expected");
+    }
 
-  try {
-    await AppWebsocket.connect({ url: ADMIN_WS_URL });
-    t.fail("websocket connection should have failed");
-  } catch (e) {
-    t.assert(e instanceof HolochainError, "expected a HolochainError");
-    t.pass("websocket connection failed as expected");
-  }
-});
+    try {
+      await AppWebsocket.connect({ url: ADMIN_WS_URL });
+      t.fail("websocket connection should have failed");
+    } catch (e) {
+      t.assert(e instanceof HolochainError, "expected a HolochainError");
+      t.pass("websocket connection failed as expected");
+    }
+  },
+);
 
 test(
   "zome call timeout can be overridden",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -780,7 +801,7 @@ test(
   }),
 );
 
-test("can inject agents", async (t) => {
+test("can inject agents", { timeout: 60_000 }, async (t) => {
   const localServices = await runLocalServices();
   const conductor1 = await launch(
     ADMIN_PORT,
@@ -868,102 +889,108 @@ test("can inject agents", async (t) => {
   await cleanSandboxConductors();
 });
 
-test("can query peer meta info over admin and app websocket", async (t) => {
-  const localServices = await runLocalServices();
-  const conductor1 = await launch(
-    ADMIN_PORT,
-    localServices.bootstrapServerUrl,
-    localServices.signalingServerUrl,
-  );
-  const {
-    cell_id: cell_id1,
-    client: appClient1,
-    admin: admin1,
-  } = await createAppWsAndInstallApp(ADMIN_PORT);
+test(
+  "can query peer meta info over admin and app websocket",
+  { timeout: 60_000 },
+  async (t) => {
+    const localServices = await runLocalServices();
+    const conductor1 = await launch(
+      ADMIN_PORT,
+      localServices.bootstrapServerUrl,
+      localServices.signalingServerUrl,
+    );
+    const {
+      cell_id: cell_id1,
+      client: appClient1,
+      admin: admin1,
+    } = await createAppWsAndInstallApp(ADMIN_PORT);
 
-  await admin1.authorizeSigningCredentials(cell_id1);
+    await admin1.authorizeSigningCredentials(cell_id1);
 
-  // Retrieve the peer URL of the agent
-  const agentInfos1 = await admin1.agentInfo({ dna_hashes: null });
-  const agentInfo1 = JSON.parse(agentInfos1[0]).agentInfo;
-  const agentUrl1 = JSON.parse(agentInfo1).url;
-  console.log("agentUrl1: ", agentUrl1);
+    // Retrieve the peer URL of the agent
+    const agentInfos1 = await admin1.agentInfo({ dna_hashes: null });
+    const agentInfo1 = JSON.parse(agentInfos1[0]).agentInfo;
+    const agentUrl1 = JSON.parse(agentInfo1).url;
+    console.log("agentUrl1: ", agentUrl1);
 
-  // Start a second conductor and install the same app
-  const conductor2 = await launch(
-    ADMIN_PORT_1,
-    localServices.bootstrapServerUrl,
-    localServices.signalingServerUrl,
-  );
+    // Start a second conductor and install the same app
+    const conductor2 = await launch(
+      ADMIN_PORT_1,
+      localServices.bootstrapServerUrl,
+      localServices.signalingServerUrl,
+    );
 
-  const {
-    cell_id: cell_id2,
-    client: appClient2,
-    admin: admin2,
-  } = await createAppWsAndInstallApp(ADMIN_PORT_1);
+    const {
+      cell_id: cell_id2,
+      client: appClient2,
+      admin: admin2,
+    } = await createAppWsAndInstallApp(ADMIN_PORT_1);
 
-  await admin2.authorizeSigningCredentials(cell_id2);
+    await admin2.authorizeSigningCredentials(cell_id2);
 
-  // Now create an entry with agent 1 to get some gossip flowing
-  const acionHash = await appClient1.callZome({
-    cell_id: cell_id1,
-    provenance: cell_id1[1],
-    zome_name: TEST_ZOME_NAME,
-    fn_name: "create_an_entry",
-    payload: null,
-  });
+    // Now create an entry with agent 1 to get some gossip flowing
+    const acionHash = await appClient1.callZome({
+      cell_id: cell_id1,
+      provenance: cell_id1[1],
+      zome_name: TEST_ZOME_NAME,
+      fn_name: "create_an_entry",
+      payload: null,
+    });
 
-  // Wait until the second agent can get it to make sure that they
-  // have exchanged peer info
-  await retryUntilTimeout<Record>(
-    () =>
-      appClient2.callZome({
-        cell_id: cell_id2,
-        provenance: cell_id2[1],
-        zome_name: TEST_ZOME_NAME,
-        fn_name: "get_an_entry",
-        payload: acionHash,
-      }),
-    null,
-    "agent 2 wasn't able to get the entry of agent 1",
-    200,
-    20_000,
-  );
+    // Wait until the second agent can get it to make sure that they
+    // have exchanged peer info
+    await retryUntilTimeout<Record>(
+      () =>
+        appClient2.callZome({
+          cell_id: cell_id2,
+          provenance: cell_id2[1],
+          zome_name: TEST_ZOME_NAME,
+          fn_name: "get_an_entry",
+          payload: acionHash,
+        }),
+      null,
+      "agent 2 wasn't able to get the entry of agent 1",
+      200,
+      20_000,
+    );
 
-  // Now have agent 2 get peer meta info for agent 1 via the admin websocket
-  const peerMetaInfos = await admin2.peerMetaInfo({ url: agentUrl1 });
+    // Now have agent 2 get peer meta info for agent 1 via the admin websocket
+    const peerMetaInfos = await admin2.peerMetaInfo({ url: agentUrl1 });
 
-  // Check that it contains gossip meta info
-  const metaInfosForDna = peerMetaInfos[encodeHashToBase64(cell_id2[0])];
-  t.assert(metaInfosForDna);
-  t.assert(metaInfosForDna["gossip:completed_rounds"].meta_value);
-  t.assert(metaInfosForDna["gossip:completed_rounds"].expires_at);
-  t.assert(metaInfosForDna["gossip:last_timestamp"].meta_value);
-  t.assert(metaInfosForDna["gossip:last_timestamp"].expires_at);
+    // Check that it contains gossip meta info
+    const metaInfosForDna = peerMetaInfos[encodeHashToBase64(cell_id2[0])];
+    t.assert(metaInfosForDna);
+    t.assert(metaInfosForDna["gossip:completed_rounds"].meta_value);
+    t.assert(metaInfosForDna["gossip:completed_rounds"].expires_at);
+    t.assert(metaInfosForDna["gossip:last_timestamp"].meta_value);
+    t.assert(metaInfosForDna["gossip:last_timestamp"].expires_at);
 
-  // Now have agent 2 get peer meta info for agent 1 via the app websocket
-  const peerMetaInfosApp = await appClient2.peerMetaInfo({ url: agentUrl1 });
+    // Now have agent 2 get peer meta info for agent 1 via the app websocket
+    const peerMetaInfosApp = await appClient2.peerMetaInfo({ url: agentUrl1 });
 
-  // Check that it contains gossip meta info
-  const metaInfosForDnaApp = peerMetaInfosApp[encodeHashToBase64(cell_id2[0])];
-  t.assert(metaInfosForDnaApp);
-  t.assert(metaInfosForDnaApp["gossip:completed_rounds"].meta_value);
-  t.assert(metaInfosForDnaApp["gossip:completed_rounds"].expires_at);
-  t.assert(metaInfosForDnaApp["gossip:last_timestamp"].meta_value);
-  t.assert(metaInfosForDnaApp["gossip:last_timestamp"].expires_at);
+    // Check that it contains gossip meta info
+    const metaInfosForDnaApp =
+      peerMetaInfosApp[encodeHashToBase64(cell_id2[0])];
+    t.assert(metaInfosForDnaApp);
+    t.assert(metaInfosForDnaApp["gossip:completed_rounds"].meta_value);
+    t.assert(metaInfosForDnaApp["gossip:completed_rounds"].expires_at);
+    t.assert(metaInfosForDnaApp["gossip:last_timestamp"].meta_value);
+    t.assert(metaInfosForDnaApp["gossip:last_timestamp"].expires_at);
 
-  await stopLocalServices(localServices.servicesProcess);
-  if (conductor1.pid) {
-    process.kill(-conductor1.pid);
-  }
-  if (conductor2.pid) {
-    process.kill(-conductor2.pid);
-  }
-  await cleanSandboxConductors();
-});
+    await stopLocalServices(localServices.servicesProcess);
+    if (conductor1.pid) {
+      process.kill(-conductor1.pid);
+    }
+    if (conductor2.pid) {
+      process.kill(-conductor2.pid);
+    }
+    await cleanSandboxConductors();
+  },
+);
 
 test(
   "can query agents over app ws",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -997,6 +1024,7 @@ test(
 
 test(
   "create link",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -1025,6 +1053,7 @@ test(
 
 test(
   "create and delete link",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -1068,6 +1097,7 @@ test(
 
 test(
   "admin smoke test: listAppInterfaces + attachAppInterface",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const admin = await AdminWebsocket.connect({
       url: ADMIN_WS_URL,
@@ -1091,6 +1121,7 @@ test(
 
 test(
   "can use some of the defined js bindings",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { installed_app_id, cell_id, client, admin } =
       await installAppAndDna(ADMIN_PORT);
@@ -1123,6 +1154,7 @@ test(
 
 test(
   "admin smoke test: install 2 hApp bundles with different network seeds",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const admin = await AdminWebsocket.connect({
       url: ADMIN_WS_URL,
@@ -1160,6 +1192,7 @@ test(
 
 test(
   "can create a callable clone cell",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin } = await installAppAndDna(ADMIN_PORT);
     const appInfo = await client.appInfo();
@@ -1200,6 +1233,7 @@ test(
 
 test(
   "can disable a clone cell",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin } = await installAppAndDna(ADMIN_PORT);
     const createCloneCellParams: CreateCloneCellRequest = {
@@ -1244,6 +1278,7 @@ test(
 
 test(
   "can enable a disabled clone cell",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin } = await installAppAndDna(ADMIN_PORT);
     const createCloneCellParams: CreateCloneCellRequest = {
@@ -1289,6 +1324,7 @@ test(
 
 test(
   "can delete archived clone cells of an app",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { installed_app_id, client, admin } =
       await installAppAndDna(ADMIN_PORT);
@@ -1322,6 +1358,7 @@ test(
 
 test(
   "requests get canceled if the websocket closes while waiting for a response",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -1375,6 +1412,7 @@ test(
 
 test(
   "can fetch storage info",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { installed_app_id, admin } = await installAppAndDna(ADMIN_PORT);
 
@@ -1391,6 +1429,7 @@ test(
 
 test(
   "can dump network stats",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, client } = await installAppAndDna(ADMIN_PORT);
 
@@ -1414,6 +1453,7 @@ test(
 
 test(
   "can dump network metrics",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { admin, cell_id, client } = await installAppAndDna(ADMIN_PORT);
 
@@ -1456,6 +1496,7 @@ test(
 
 test(
   "can update coordinators of an app",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -1505,6 +1546,7 @@ test(
 
 test(
   "client reconnects websocket if closed before making a zome call",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(
       ADMIN_PORT,
@@ -1531,6 +1573,7 @@ test(
 
 test(
   "client fails to reconnect to websocket if closed before making a zome call if the provided token is invalid",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { cell_id, client, admin } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -1583,6 +1626,7 @@ test(
 
 test(
   "Rust enums are serialized correctly",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);

--- a/test/e2e/launcher.ts
+++ b/test/e2e/launcher.ts
@@ -16,6 +16,7 @@ const TEST_ZOME_NAME = "foo";
 
 test(
   "AdminWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore-next-line
@@ -33,6 +34,7 @@ test(
 
 test(
   "AppWebsocket connects with options provided by window.__HC_LAUNCHER_ENV__",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore-next-line
@@ -56,6 +58,7 @@ test(
 
 test(
   "AppWebsocket uses the zome call signer function provided by window.__HC_ZOME_CALL_SIGNER__",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore-next-line

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -31,6 +31,7 @@ const TEST_ZOME_NAME = "foo";
 
 test(
   "fakeAgentPubKey generates valid AgentPubKey",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -53,6 +54,7 @@ test(
 
 test(
   "fakeEntryHash generates valid EntryHash",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -75,6 +77,7 @@ test(
 
 test(
   "fakeActionHash generates valid ActionHash",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -97,6 +100,7 @@ test(
 
 test(
   "fakeDnaHash generates valid DnaHash",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -119,6 +123,7 @@ test(
 
 test(
   "fakeAgentPubKey generates deterministic valid AgentPubKey when coreByte defined",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -144,6 +149,7 @@ test(
 
 test(
   "fakeEntryHash generates deterministic valid EntryHash when coreByte defined",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -169,6 +175,7 @@ test(
 
 test(
   "fakeActionHash generates deterministic valid ActionHash  when coreByte defined",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -194,6 +201,7 @@ test(
 
 test(
   "fakeDnaHash generates deterministic valid DnaHash when coreByte defined",
+  { timeout: 60_000 },
   withConductor(ADMIN_PORT, async (t) => {
     const { client, admin, cell_id } = await installAppAndDna(ADMIN_PORT);
     await admin.authorizeSigningCredentials(cell_id);
@@ -217,436 +225,474 @@ test(
   }),
 );
 
-test("sliceDhtLocation, sliceCore32, sliceHashType extract components of a hash", async (t) => {
-  const fakeHash = await fakeDnaHash(1);
-  const prefix = sliceHashType(fakeHash);
-  const hash = sliceCore32(fakeHash);
-  const dhtLocation = sliceDhtLocation(fakeHash);
+test(
+  "sliceDhtLocation, sliceCore32, sliceHashType extract components of a hash",
+  { timeout: 60_000 },
+  async (t) => {
+    const fakeHash = await fakeDnaHash(1);
+    const prefix = sliceHashType(fakeHash);
+    const hash = sliceCore32(fakeHash);
+    const dhtLocation = sliceDhtLocation(fakeHash);
 
-  t.deepEqual(
-    fakeHash,
-    Uint8Array.from([...prefix, ...hash, ...dhtLocation]),
-    "extracted hash type, core hash, and dht location components of a hash concat back into the original hash",
-  );
-});
+    t.deepEqual(
+      fakeHash,
+      Uint8Array.from([...prefix, ...hash, ...dhtLocation]),
+      "extracted hash type, core hash, and dht location components of a hash concat back into the original hash",
+    );
+  },
+);
 
-test("hashFrom32AndType generates valid hash with type and 32 core bytes", async (t) => {
-  const core = Uint8Array.from(range(0, 32).map(() => 1));
+test(
+  "hashFrom32AndType generates valid hash with type and 32 core bytes",
+  { timeout: 60_000 },
+  async (t) => {
+    const core = Uint8Array.from(range(0, 32).map(() => 1));
 
-  let hash = hashFrom32AndType(core, HoloHashType.Agent);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 32, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.Entry);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 33, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.DhtOp);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 36, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.Warrant);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 44, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.Dna);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 45, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.Action);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 41, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.Wasm);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 42, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-
-  hash = hashFrom32AndType(core, HoloHashType.External);
-  t.deepEqual(
-    hash,
-    Uint8Array.from([
-      132, 47, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-    "generated full valid hash",
-  );
-});
-
-test("getHashType determines hash type name from valid 39 byte hash", async (t) => {
-  let hashType = getHashType(
-    Uint8Array.from([
-      132, 32, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Agent);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 33, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Entry);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 36, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.DhtOp);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 44, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Warrant);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 45, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Dna);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 41, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Action);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 42, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.Wasm);
-
-  hashType = getHashType(
-    Uint8Array.from([
-      132, 47, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
-    ]),
-  );
-  t.equal(hashType, HoloHashType.External);
-});
-
-test("getHashType throws error on hash with invalid 3 byte prefix", async (t) => {
-  // Invalid hash type prefix throws error
-  t.throws(() => {
-    getHashType(
+    let hash = hashFrom32AndType(core, HoloHashType.Agent);
+    t.deepEqual(
+      hash,
       Uint8Array.from([
-        0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+        132, 32, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.Entry);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 33, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.DhtOp);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 36, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.Warrant);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 44, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.Dna);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 45, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.Action);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 41, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.Wasm);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 42, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+
+    hash = hashFrom32AndType(core, HoloHashType.External);
+    t.deepEqual(
+      hash,
+      Uint8Array.from([
+        132, 47, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+      "generated full valid hash",
+    );
+  },
+);
+
+test(
+  "getHashType determines hash type name from valid 39 byte hash",
+  { timeout: 60_000 },
+  async (t) => {
+    let hashType = getHashType(
+      Uint8Array.from([
+        132, 32, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
       ]),
     );
-  });
-});
+    t.equal(hashType, HoloHashType.Agent);
 
-test("hashFromContentAndType generates valid HoloHash with specified type", async (t) => {
-  const content = {
-    name: "Joe",
-    age: 20,
-    hobbies: ["Ice Skating", "Basketball", "Dance"],
-  };
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 33, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.Entry);
 
-  // Determine expected hash by hashing manually with blake2
-  const expectedHash = new Uint8Array(32);
-  blake2b(expectedHash.length).update(encode(content)).digest(expectedHash);
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 36, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.DhtOp);
 
-  // Hash from util function
-  const hash = hashFromContentAndType(content, HoloHashType.Entry);
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 44, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.Warrant);
 
-  // Valid type bytes
-  const hashType = getHashType(hash);
-  t.deepEqual(hashType, HoloHashType.Entry);
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 45, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.Dna);
 
-  // Valid hash bytes
-  const core = sliceCore32(hash);
-  t.deepEqual(core.length, 32);
-  t.deepEqual(core, expectedHash);
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 41, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.Action);
 
-  // Valid location bytes
-  const loc = sliceDhtLocation(hash);
-  t.deepEqual(loc, dhtLocationFrom32(expectedHash));
-});
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 42, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.Wasm);
 
-test("HoloHashB64Map is a map from HoloHashB64 to a value", async (t) => {
-  interface Person {
-    name: string;
-  }
+    hashType = getHashType(
+      Uint8Array.from([
+        132, 47, 36, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+      ]),
+    );
+    t.equal(hashType, HoloHashType.External);
+  },
+);
 
-  const bobKey = encodeHashToBase64(await fakeAgentPubKey(1));
-  const bobVal = { name: "Bob" };
+test(
+  "getHashType throws error on hash with invalid 3 byte prefix",
+  { timeout: 60_000 },
+  async (t) => {
+    // Invalid hash type prefix throws error
+    t.throws(() => {
+      getHashType(
+        Uint8Array.from([
+          0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 126, 207, 206, 190,
+        ]),
+      );
+    });
+  },
+);
 
-  // Set initial entries
-  const hhmap = new HoloHashB64Map<AgentPubKeyB64, Person>([[bobKey, bobVal]]);
+test(
+  "hashFromContentAndType generates valid HoloHash with specified type",
+  { timeout: 60_000 },
+  async (t) => {
+    const content = {
+      name: "Joe",
+      age: 20,
+      hobbies: ["Ice Skating", "Basketball", "Dance"],
+    };
 
-  // Get
-  t.deepEqual(hhmap.get(bobKey), bobVal);
+    // Determine expected hash by hashing manually with blake2
+    const expectedHash = new Uint8Array(32);
+    blake2b(expectedHash.length).update(encode(content)).digest(expectedHash);
 
-  // Set
-  const aliceKey = encodeHashToBase64(await fakeAgentPubKey(2));
-  const aliceVal = { name: "Alice" };
-  hhmap.set(aliceKey, aliceVal);
-  t.deepEqual(hhmap.get(aliceKey), aliceVal);
+    // Hash from util function
+    const hash = hashFromContentAndType(content, HoloHashType.Entry);
 
-  // Size
-  t.equal(hhmap.size, 2);
+    // Valid type bytes
+    const hashType = getHashType(hash);
+    t.deepEqual(hashType, HoloHashType.Entry);
 
-  // Keys
-  t.deepEqual(Array.from(hhmap.keys()), [bobKey, aliceKey]);
+    // Valid hash bytes
+    const core = sliceCore32(hash);
+    t.deepEqual(core.length, 32);
+    t.deepEqual(core, expectedHash);
 
-  // Values
-  t.deepEqual(Array.from(hhmap.values()), [bobVal, aliceVal]);
+    // Valid location bytes
+    const loc = sliceDhtLocation(hash);
+    t.deepEqual(loc, dhtLocationFrom32(expectedHash));
+  },
+);
 
-  // Entries
-  t.deepEqual(Array.from(hhmap.entries()), [
-    [bobKey, bobVal],
-    [aliceKey, aliceVal],
-  ]);
+test(
+  "HoloHashB64Map is a map from HoloHashB64 to a value",
+  { timeout: 60_000 },
+  async (t) => {
+    interface Person {
+      name: string;
+    }
 
-  // For each
-  const keys = [];
-  hhmap.forEach((_v, k) => {
-    keys.push(k);
-  });
-  t.equal(keys.length, 2);
-
-  // for..of
-  const keys2 = [];
-  for (const [k] of hhmap) {
-    keys2.push(k);
-  }
-  t.equal(keys2.length, 2);
-
-  // Delete by key
-  t.true(hhmap.delete(aliceKey));
-  t.equal(hhmap.get(aliceKey), undefined);
-
-  // Clear
-  hhmap.clear();
-  t.equal(hhmap.size, 0);
-});
-
-test("HoloHashMap is a map from HoloHash to a value", async (t) => {
-  interface Person {
-    name: string;
-  }
-
-  const bobKey = await fakeAgentPubKey(1);
-  const bobVal = { name: "Bob" };
-
-  // Set initial entries
-  const hhmap = new HoloHashMap<AgentPubKey, Person>([[bobKey, bobVal]]);
-
-  // Get
-  t.deepEqual(hhmap.get(bobKey), bobVal);
-
-  // Set
-  const aliceKey = await fakeAgentPubKey(2);
-  const aliceVal = { name: "Alice" };
-  hhmap.set(aliceKey, aliceVal);
-  t.deepEqual(hhmap.get(aliceKey), aliceVal);
-
-  // Has
-  t.true(hhmap.has(aliceKey));
-
-  // Size
-  t.equal(hhmap.size, 2);
-
-  // Keys
-  t.deepEqual(Array.from(hhmap.keys()), [bobKey, aliceKey]);
-
-  // Values
-  t.deepEqual(Array.from(hhmap.values()), [bobVal, aliceVal]);
-
-  // Entries
-  t.deepEqual(Array.from(hhmap.entries()), [
-    [bobKey, bobVal],
-    [aliceKey, aliceVal],
-  ]);
-
-  // forEach
-  const keys = [];
-  hhmap.forEach((_v, k) => {
-    keys.push(k);
-  });
-  t.equal(keys.length, 2);
-
-  // for..of
-  const keys2 = [];
-  for (const [k] of hhmap) {
-    keys2.push(k);
-  }
-  t.equal(keys2.length, 2);
-
-  // Delete by key
-  t.true(hhmap.delete(aliceKey));
-  t.equal(hhmap.get(aliceKey), undefined);
-
-  // Clear
-  hhmap.clear();
-  t.equal(hhmap.size, 0);
-});
-
-test("LazyHoloHashMap is a map from HoloHash to a value that fetches the value if not available", async (t) => {
-  interface Person {
-    name: string;
-  }
-
-  const bobKey = await fakeAgentPubKey(1);
-  const bobVal = { name: "Bob" };
-
-  const aliceKey = await fakeAgentPubKey(2);
-  const aliceVal = { name: "Alice" };
-
-  const hhmap = new LazyHoloHashMap<AgentPubKey, Person>(
-    // Set function to fetch val
-    (key: AgentPubKey) => {
-      if (key === aliceKey) {
-        return aliceVal;
-      }
-    },
+    const bobKey = encodeHashToBase64(await fakeAgentPubKey(1));
+    const bobVal = { name: "Bob" };
 
     // Set initial entries
-    [[bobKey, bobVal]],
-  );
-  t.deepEqual(hhmap.get(bobKey), bobVal);
+    const hhmap = new HoloHashB64Map<AgentPubKeyB64, Person>([
+      [bobKey, bobVal],
+    ]);
 
-  // Get fetches the value if missing
-  t.deepEqual(hhmap.get(aliceKey), aliceVal);
-});
+    // Get
+    t.deepEqual(hhmap.get(bobKey), bobVal);
 
-test("DnaHoloHashMap is a map from a DnaHash to a HoloHashMap", async (t) => {
-  interface Person {
-    name: string;
-  }
+    // Set
+    const aliceKey = encodeHashToBase64(await fakeAgentPubKey(2));
+    const aliceVal = { name: "Alice" };
+    hhmap.set(aliceKey, aliceVal);
+    t.deepEqual(hhmap.get(aliceKey), aliceVal);
 
-  const homeDna = await fakeDnaHash(1);
-  const bobKey = await fakeAgentPubKey(1);
-  const bobVal = { name: "Bob" };
+    // Size
+    t.equal(hhmap.size, 2);
 
-  // Set initial entries
-  const hhmap = new DnaHoloHashMap<AgentPubKey, Person>([
-    [[homeDna, bobKey], bobVal],
-  ]);
+    // Keys
+    t.deepEqual(Array.from(hhmap.keys()), [bobKey, aliceKey]);
 
-  // Get
-  t.deepEqual(hhmap.get([homeDna, bobKey]), bobVal);
+    // Values
+    t.deepEqual(Array.from(hhmap.values()), [bobVal, aliceVal]);
 
-  // Set
-  const aliceKey = await fakeAgentPubKey(2);
-  const aliceVal = { name: "Alice" };
-  hhmap.set([homeDna, aliceKey], aliceVal);
-  t.deepEqual(hhmap.get([homeDna, aliceKey]), aliceVal);
+    // Entries
+    t.deepEqual(Array.from(hhmap.entries()), [
+      [bobKey, bobVal],
+      [aliceKey, aliceVal],
+    ]);
 
-  // Has
-  t.true(hhmap.has([homeDna, aliceKey]));
+    // For each
+    const keys = [];
+    hhmap.forEach((_v, k) => {
+      keys.push(k);
+    });
+    t.equal(keys.length, 2);
 
-  // Keys
-  t.deepEqual(hhmap.keys(), [
-    [homeDna, bobKey],
-    [homeDna, aliceKey],
-  ]);
+    // for..of
+    const keys2 = [];
+    for (const [k] of hhmap) {
+      keys2.push(k);
+    }
+    t.equal(keys2.length, 2);
 
-  // Values
-  t.deepEqual(hhmap.values(), [bobVal, aliceVal]);
+    // Delete by key
+    t.true(hhmap.delete(aliceKey));
+    t.equal(hhmap.get(aliceKey), undefined);
 
-  // Entries
-  t.deepEqual(hhmap.entries(), [
-    [[homeDna, bobKey], bobVal],
-    [[homeDna, aliceKey], aliceVal],
-  ]);
+    // Clear
+    hhmap.clear();
+    t.equal(hhmap.size, 0);
+  },
+);
 
-  // Set for Other Dna
-  const workDna = await fakeDnaHash(3);
-  const sueKey = await fakeAgentPubKey(3);
-  const sueVal = { name: "Sue" };
-  hhmap.set([workDna, sueKey], sueVal);
-  t.deepEqual(hhmap.get([workDna, sueKey]), sueVal);
+test(
+  "HoloHashMap is a map from HoloHash to a value",
+  { timeout: 60_000 },
+  async (t) => {
+    interface Person {
+      name: string;
+    }
 
-  // Keys for Dna
-  t.deepEqual(hhmap.keysForDna(homeDna), [bobKey, aliceKey]);
-  t.deepEqual(hhmap.keysForDna(workDna), [sueKey]);
+    const bobKey = await fakeAgentPubKey(1);
+    const bobVal = { name: "Bob" };
 
-  // Values for Dna
-  t.deepEqual(hhmap.valuesForDna(homeDna), [bobVal, aliceVal]);
-  t.deepEqual(hhmap.valuesForDna(workDna), [sueVal]);
+    // Set initial entries
+    const hhmap = new HoloHashMap<AgentPubKey, Person>([[bobKey, bobVal]]);
 
-  // Entries for Dna
-  t.deepEqual(hhmap.entriesForDna(homeDna), [
-    [bobKey, bobVal],
-    [aliceKey, aliceVal],
-  ]);
-  t.deepEqual(hhmap.entriesForDna(workDna), [[sueKey, sueVal]]);
+    // Get
+    t.deepEqual(hhmap.get(bobKey), bobVal);
 
-  // filter
-  const res2 = hhmap.filter((v) => isEqual(v, bobVal));
-  t.equal(res2.get([homeDna, aliceKey]), undefined);
+    // Set
+    const aliceKey = await fakeAgentPubKey(2);
+    const aliceVal = { name: "Alice" };
+    hhmap.set(aliceKey, aliceVal);
+    t.deepEqual(hhmap.get(aliceKey), aliceVal);
 
-  // map
-  const res3 = hhmap.map((v) => (isEqual(v, bobVal) ? { name: "Tom" } : v));
-  t.deepEqual(res3.get([homeDna, bobKey]), { name: "Tom" });
+    // Has
+    t.true(hhmap.has(aliceKey));
 
-  // Delete by key
-  t.equal(true, hhmap.delete([homeDna, bobKey]));
-  t.equal(hhmap.get([homeDna, bobKey]), undefined);
+    // Size
+    t.equal(hhmap.size, 2);
 
-  // Clear for Dna
-  hhmap.clearForDna(homeDna);
-  t.equal(hhmap.get([homeDna, bobKey]), undefined);
+    // Keys
+    t.deepEqual(Array.from(hhmap.keys()), [bobKey, aliceKey]);
 
-  // Clear
-  hhmap.clear();
-  t.equal(hhmap.size, 0);
-});
+    // Values
+    t.deepEqual(Array.from(hhmap.values()), [bobVal, aliceVal]);
+
+    // Entries
+    t.deepEqual(Array.from(hhmap.entries()), [
+      [bobKey, bobVal],
+      [aliceKey, aliceVal],
+    ]);
+
+    // forEach
+    const keys = [];
+    hhmap.forEach((_v, k) => {
+      keys.push(k);
+    });
+    t.equal(keys.length, 2);
+
+    // for..of
+    const keys2 = [];
+    for (const [k] of hhmap) {
+      keys2.push(k);
+    }
+    t.equal(keys2.length, 2);
+
+    // Delete by key
+    t.true(hhmap.delete(aliceKey));
+    t.equal(hhmap.get(aliceKey), undefined);
+
+    // Clear
+    hhmap.clear();
+    t.equal(hhmap.size, 0);
+  },
+);
+
+test(
+  "LazyHoloHashMap is a map from HoloHash to a value that fetches the value if not available",
+  { timeout: 60_000 },
+  async (t) => {
+    interface Person {
+      name: string;
+    }
+
+    const bobKey = await fakeAgentPubKey(1);
+    const bobVal = { name: "Bob" };
+
+    const aliceKey = await fakeAgentPubKey(2);
+    const aliceVal = { name: "Alice" };
+
+    const hhmap = new LazyHoloHashMap<AgentPubKey, Person>(
+      // Set function to fetch val
+      (key: AgentPubKey) => {
+        if (key === aliceKey) {
+          return aliceVal;
+        }
+      },
+
+      // Set initial entries
+      [[bobKey, bobVal]],
+    );
+    t.deepEqual(hhmap.get(bobKey), bobVal);
+
+    // Get fetches the value if missing
+    t.deepEqual(hhmap.get(aliceKey), aliceVal);
+  },
+);
+
+test(
+  "DnaHoloHashMap is a map from a DnaHash to a HoloHashMap",
+  { timeout: 60_000 },
+  async (t) => {
+    interface Person {
+      name: string;
+    }
+
+    const homeDna = await fakeDnaHash(1);
+    const bobKey = await fakeAgentPubKey(1);
+    const bobVal = { name: "Bob" };
+
+    // Set initial entries
+    const hhmap = new DnaHoloHashMap<AgentPubKey, Person>([
+      [[homeDna, bobKey], bobVal],
+    ]);
+
+    // Get
+    t.deepEqual(hhmap.get([homeDna, bobKey]), bobVal);
+
+    // Set
+    const aliceKey = await fakeAgentPubKey(2);
+    const aliceVal = { name: "Alice" };
+    hhmap.set([homeDna, aliceKey], aliceVal);
+    t.deepEqual(hhmap.get([homeDna, aliceKey]), aliceVal);
+
+    // Has
+    t.true(hhmap.has([homeDna, aliceKey]));
+
+    // Keys
+    t.deepEqual(hhmap.keys(), [
+      [homeDna, bobKey],
+      [homeDna, aliceKey],
+    ]);
+
+    // Values
+    t.deepEqual(hhmap.values(), [bobVal, aliceVal]);
+
+    // Entries
+    t.deepEqual(hhmap.entries(), [
+      [[homeDna, bobKey], bobVal],
+      [[homeDna, aliceKey], aliceVal],
+    ]);
+
+    // Set for Other Dna
+    const workDna = await fakeDnaHash(3);
+    const sueKey = await fakeAgentPubKey(3);
+    const sueVal = { name: "Sue" };
+    hhmap.set([workDna, sueKey], sueVal);
+    t.deepEqual(hhmap.get([workDna, sueKey]), sueVal);
+
+    // Keys for Dna
+    t.deepEqual(hhmap.keysForDna(homeDna), [bobKey, aliceKey]);
+    t.deepEqual(hhmap.keysForDna(workDna), [sueKey]);
+
+    // Values for Dna
+    t.deepEqual(hhmap.valuesForDna(homeDna), [bobVal, aliceVal]);
+    t.deepEqual(hhmap.valuesForDna(workDna), [sueVal]);
+
+    // Entries for Dna
+    t.deepEqual(hhmap.entriesForDna(homeDna), [
+      [bobKey, bobVal],
+      [aliceKey, aliceVal],
+    ]);
+    t.deepEqual(hhmap.entriesForDna(workDna), [[sueKey, sueVal]]);
+
+    // filter
+    const res2 = hhmap.filter((v) => isEqual(v, bobVal));
+    t.equal(res2.get([homeDna, aliceKey]), undefined);
+
+    // map
+    const res3 = hhmap.map((v) => (isEqual(v, bobVal) ? { name: "Tom" } : v));
+    t.deepEqual(res3.get([homeDna, bobKey]), { name: "Tom" });
+
+    // Delete by key
+    t.equal(true, hhmap.delete([homeDna, bobKey]));
+    t.equal(hhmap.get([homeDna, bobKey]), undefined);
+
+    // Clear for Dna
+    hhmap.clearForDna(homeDna);
+    t.equal(hhmap.get([homeDna, bobKey]), undefined);
+
+    // Clear
+    hhmap.clear();
+    t.equal(hhmap.size, 0);
+  },
+);


### PR DESCRIPTION
### Summary
Adds timeouts to tests. With the `tape` test runner, this cannot be done globally, so must be set on every test. 

Inconsistently tests are taking > 6 hours to run and exceeding the github runner limit.

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test suite configuration with improved timeout handling to enhance test stability and reliability across multiple test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->