### PR TITLE
Update flake lock to 0.6.1-rc.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1768873933,
-        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764163563,
-        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
+        "lastModified": 1774456561,
+        "narHash": "sha256-CQ3HUE++iyLWJFK9wt2TeusmbuLavGxF8kxnv8mMsVw=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
+        "rev": "3329e3c01572dc525ee95caa3d179dc659134572",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.1",
+        "ref": "v0.600.3-rc.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -53,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1769035817,
-        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
+        "lastModified": 1774368245,
+        "narHash": "sha256-Cx7vdPRvPNDcY+I20Sr/db/xP9hkGWww2XtDrvWLilE=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
+        "rev": "dbaec635a8034a8a1404a858d6153e2865218150",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.1-rc.0",
+        "ref": "holochain-0.6.1-rc.4",
         "repo": "holochain",
         "type": "github"
       }
@@ -79,11 +79,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1769045727,
-        "narHash": "sha256-sYGlDJ6pNt3n+Tu5F86Lsr8ki+TfGMRGeSrDz+MSv+w=",
+        "lastModified": 1774473196,
+        "narHash": "sha256-8N++/mv7fgCFO5tJELxT/WR7ZjkKKGxpBC1VwQnR7cM=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "7b46630e1bd47b25d1f6385d8e921435f453c1a7",
+        "rev": "dd6214c7b3ec2392333a1e9323d3bba363a9b632",
         "type": "github"
       },
       "original": {
@@ -96,16 +96,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1767421208,
-        "narHash": "sha256-hPIesp4R8/8sA+Qqw1ECgsgCOKlyX5coGR+7QDoavWw=",
+        "lastModified": 1774309351,
+        "narHash": "sha256-/MZY9DmZW2x9FHmeVdNtL8GIQqqvTndqQ33egH1ugGA=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "77471c1fb4b6f926609bf82152dc97e26457b4d9",
+        "rev": "cf1cbea90aae348bf41b3ee6a63c2c5fffa493fb",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.4.0-dev.2",
+        "ref": "v0.4.0-dev.6",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768940263,
-        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
+        "lastModified": 1774244481,
+        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
+        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768963622,
-        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
+        "lastModified": 1774321696,
+        "narHash": "sha256-g18xMjMNla/nsF5XyQCNyWmtb2UlZpkY0XE8KinIXAA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
+        "rev": "49a67e6894d4cb782842ee6faa466aa90c92812d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Summary


### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)
