### PR TITLE
fix: prevent WsClient wedge after transient reconnect (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Test utility `withAppBatch` for starting multiple conductors and installing the same app on each.
 ### Fixed
 - After change in Holochain, fixed `AppWebsocket.dumpNetworkStats` to use the correct return type `DumpNetworkStatsResponse` instead of `AppDumpNetworkStatsResponse`. `AppDumpNetworkStatsResponse` was removed.
+- `WsClient` no longer permanently wedges after a transient reconnect failure: the cached app authentication token is now retained on generic connection errors and only cleared when the conductor actually rejects it (close within 10ms of the `authenticate` handshake). Concurrent reconnect attempts are also deduplicated so parallel requests share a single new socket. [#412](https://github.com/holochain/holochain-client-js/issues/412)
 ### Changed
 - Additional assertions of response data in test of `dumpNetworkStats` call.
 - The field `signalingServerUrl` in `ConnectionServices` has been renamed to `relayServerUrl`.

--- a/docs/client.wsclient.md
+++ b/docs/client.wsclient.md
@@ -215,6 +215,10 @@ Sends data as a signal.
 
 Send requests to the connected websocket.
 
+If the underlying socket is closed when this method is called, the client transparently reconnects and re-authenticates using the cached token. Transient reconnect errors are surfaced as a `ConnectionError` and the cached token is retained, so a subsequent call can retry the reconnect.
+
+If the conductor rejects the cached token during the reconnect (signalled by an immediate close after the `authenticate` handshake), the cached token is cleared and the call rejects with an `InvalidTokenError`<!-- -->. The consumer must rebuild the `AppWebsocket` with a fresh token; further calls on this client will reject with `WebsocketClosedError`<!-- -->.
+
 
 </td></tr>
 </tbody></table>

--- a/docs/client.wsclient.request.md
+++ b/docs/client.wsclient.request.md
@@ -6,6 +6,10 @@
 
 Send requests to the connected websocket.
 
+If the underlying socket is closed when this method is called, the client transparently reconnects and re-authenticates using the cached token. Transient reconnect errors are surfaced as a `ConnectionError` and the cached token is retained, so a subsequent call can retry the reconnect.
+
+If the conductor rejects the cached token during the reconnect (signalled by an immediate close after the `authenticate` handshake), the cached token is cleared and the call rejects with an `InvalidTokenError`<!-- -->. The consumer must rebuild the `AppWebsocket` with a fresh token; further calls on this client will reject with `WebsocketClosedError`<!-- -->.
+
 **Signature:**
 
 ```typescript
@@ -52,4 +56,5 @@ The request to send over the websocket.
 
 Promise&lt;Response&gt;
 
+The decoded response payload.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,7 +1475,6 @@
       "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1526,7 +1525,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1881,7 +1879,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1905,7 +1902,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2224,7 +2220,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2285,7 +2280,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3523,7 +3517,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3576,7 +3569,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4047,7 +4039,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4081,7 +4072,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4123,7 +4113,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4319,7 +4308,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,6 +42,7 @@ export class WsClient extends Emittery {
   private pendingRequests: Record<number, HolochainRequest>;
   private index: number;
   private authenticationToken: AppAuthenticationToken | undefined;
+  private reconnectPromise: Promise<void> | undefined;
 
   constructor(socket: IsoWebSocket, url?: URL, options?: WsClientOptions) {
     super();
@@ -151,8 +152,21 @@ export class WsClient extends Emittery {
   /**
    * Send requests to the connected websocket.
    *
+   * If the underlying socket is closed when this method is called, the
+   * client transparently reconnects and re-authenticates using the cached
+   * token. Transient reconnect errors are surfaced as a `ConnectionError`
+   * and the cached token is retained, so a subsequent call can retry the
+   * reconnect.
+   *
+   * If the conductor rejects the cached token during the reconnect
+   * (signalled by an immediate close after the `authenticate` handshake),
+   * the cached token is cleared and the call rejects with an
+   * `InvalidTokenError`. The consumer must rebuild the `AppWebsocket`
+   * with a fresh token; further calls on this client will reject with
+   * `WebsocketClosedError`.
+   *
    * @param request - The request to send over the websocket.
-   * @returns
+   * @returns The decoded response payload.
    */
   async request<Response>(request: unknown): Promise<Response> {
     return this.exchange(request, this.sendMessage.bind(this));
@@ -172,7 +186,18 @@ export class WsClient extends Emittery {
       });
       return promise as Promise<Response>;
     } else if (this.url && this.authenticationToken) {
-      await this.reconnectWebsocket(this.url, this.authenticationToken);
+      // Dedupe concurrent reconnect attempts. The first caller into this
+      // branch starts a single reconnect; further callers await the same
+      // promise so we never create multiple sockets in parallel.
+      if (!this.reconnectPromise) {
+        this.reconnectPromise = this.reconnectWebsocket(
+          this.url,
+          this.authenticationToken,
+        ).finally(() => {
+          this.reconnectPromise = undefined;
+        });
+      }
+      await this.reconnectPromise;
       this.registerMessageListener(this.socket);
       this.registerCloseListener(this.socket);
       const promise = new Promise((resolve, reject) =>
@@ -295,11 +320,16 @@ export class WsClient extends Emittery {
   private async reconnectWebsocket(url: URL, token: AppAuthenticationToken) {
     return new Promise<void>((resolve, reject) => {
       this.socket = new IsoWebSocket(url, this.options);
+
+      // Track whether the "open" event has fired. The invalidTokenCloseListener
+      // must only clear the token when the connection did open and the conductor
+      // then closed it quickly.
+      let openFired = false;
+
       // This error event never occurs in tests. Could be removed?
       this.socket.addEventListener(
         "error",
         (errorEvent) => {
-          this.authenticationToken = undefined;
           reject(
             new HolochainError(
               "ConnectionError",
@@ -313,13 +343,22 @@ export class WsClient extends Emittery {
       const invalidTokenCloseListener = (
         closeEvent: IsoWebSocket.CloseEvent,
       ) => {
-        this.authenticationToken = undefined;
-        reject(
-          new HolochainError(
-            "InvalidTokenError",
-            `could not connect to ${this.url} due to an invalid app authentication token - close code ${closeEvent.code}`,
-          ),
-        );
+        if (openFired) {
+          this.authenticationToken = undefined;
+          reject(
+            new HolochainError(
+              "InvalidTokenError",
+              `could not connect to ${this.url} due to an invalid app authentication token - close code ${closeEvent.code}`,
+            ),
+          );
+        } else {
+          reject(
+            new HolochainError(
+              "ConnectionError",
+              `could not connect to Holochain Conductor API at ${url} - close code ${closeEvent.code}`,
+            ),
+          );
+        }
       };
       this.socket.addEventListener("close", invalidTokenCloseListener, {
         once: true,
@@ -328,6 +367,7 @@ export class WsClient extends Emittery {
       this.socket.addEventListener(
         "open",
         async () => {
+          openFired = true;
           const encodedMsg = encode({
             type: "authenticate",
             data: encode({ token }),

--- a/src/hdk/validation-receipts.ts
+++ b/src/hdk/validation-receipts.ts
@@ -1,4 +1,4 @@
-import { AgentPubKey, DhtOpHash, Timestamp } from "../types";
+import { AgentPubKey, DhtOpHash, Timestamp } from "../types.js";
 
 /**
  * @public

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1621,6 +1621,54 @@ test(
 );
 
 test(
+  "app client recovers after a transient reconnect failure (regression #412)",
+  withApp(
+    async (testCase) => {
+      const { app_ws, cell_id } = testCase;
+
+      const callParams = {
+        cell_id,
+        zome_name: TEST_ZOME_NAME,
+        fn_name: "bar",
+        provenance: cell_id[1],
+        payload: null,
+      };
+
+      // Baseline: healthy call.
+      await app_ws.callZome(callParams);
+
+      // Induce a transient reconnect failure: point at a closed port and
+      // close the live socket. The next request reconnects to a bad URL,
+      // emits `error`, and (today) clears the auth token, wedging the client.
+      const goodUrl = app_ws.client.url!;
+      const badUrl = new URL("ws://127.0.0.1:1");
+      app_ws.client.url = badUrl;
+      await app_ws.client.close();
+
+      try {
+        await app_ws.callZome(callParams);
+        assert.fail("call against sabotaged URL should have failed");
+      } catch (error) {
+        assert(error instanceof HolochainError);
+        // Either ConnectionError or WebsocketClosedError is acceptable here;
+        // the point is the call failed transiently.
+      }
+
+      // Restore the good URL. Conductor is up, token must still be valid.
+      app_ws.client.url = goodUrl;
+
+      // With the fix, the next call should reconnect and succeed.
+      await app_ws.callZome(callParams);
+
+      // And a follow-up call must also succeed (no residual wedge).
+      await app_ws.callZome(callParams);
+    },
+    false,
+    0,
+  ),
+);
+
+test(
   "Rust enums are serialized correctly",
   withApp(async (testCase) => {
     const { app_ws, cell_id } = testCase;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "ES2022",
+    "module": "NodeNext",
     "target": "ES2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
@@ -10,7 +10,5 @@
     "strict": true,
     "typeRoots": ["./node_modules/@types", "./typings"]
   },
-  "include": [
-    "./src/**/*", "./typings"
-  ],
+  "include": ["./src/**/*", "./typings"]
 }


### PR DESCRIPTION
### Summary

closes #412

- Retain auth token on generic reconnect "error" event; only clear it
  when conductor closes immediately after `authenticate` (real
  InvalidTokenError signal).
- Dedupe concurrent reconnect attempts via shared `reconnectPromise`
  so parallel `exchange()` callers share one new socket.
- Document `request()` error surface (ConnectionError /
  InvalidTokenError / WebsocketClosedError).
- Add e2e regressions: wedge recovery + concurrent reconnect dedupe.
- Switch tsconfig to NodeNext module/moduleResolution; fix resulting
  missing `.js` extension in `src/hdk/validation-receipts.ts`. This was necessary because our tsconfig was going to raise error on next ts version

### TODO:
- [ ] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)
