### PR TITLE
fix: prevent WsClient wedge after transient reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 ### Fixed
+
+- After change in Holochain, fixed `AppWebsocket.dumpNetworkStats` to use the correct return type `DumpNetworkStatsResponse` instead of `AppDumpNetworkStatsResponse`. `AppDumpNetworkStatsResponse` was removed.
+- `WsClient` no longer permanently wedges after a transient reconnect failure: the cached app authentication token is now retained on generic connection errors and only cleared when the conductor actually rejects it (close within 10ms of the `authenticate` handshake). Concurrent reconnect attempts are also deduplicated so parallel requests share a single new socket. [#412](https://github.com/holochain/holochain-client-js/issues/412)
+
 ### Changed
 ### Removed
 

--- a/docs/client.wsclient.md
+++ b/docs/client.wsclient.md
@@ -215,6 +215,10 @@ Sends data as a signal.
 
 Send requests to the connected websocket.
 
+If the underlying socket is closed when this method is called, the client transparently reconnects and re-authenticates using the cached token. Transient reconnect errors are surfaced as a `ConnectionError` and the cached token is retained, so a subsequent call can retry the reconnect.
+
+If the conductor rejects the cached token during the reconnect (signalled by an immediate close after the `authenticate` handshake), the cached token is cleared and the call rejects with an `InvalidTokenError`<!-- -->. The consumer must rebuild the `AppWebsocket` with a fresh token; further calls on this client will reject with `WebsocketClosedError`<!-- -->.
+
 
 </td></tr>
 </tbody></table>

--- a/docs/client.wsclient.request.md
+++ b/docs/client.wsclient.request.md
@@ -6,6 +6,10 @@
 
 Send requests to the connected websocket.
 
+If the underlying socket is closed when this method is called, the client transparently reconnects and re-authenticates using the cached token. Transient reconnect errors are surfaced as a `ConnectionError` and the cached token is retained, so a subsequent call can retry the reconnect.
+
+If the conductor rejects the cached token during the reconnect (signalled by an immediate close after the `authenticate` handshake), the cached token is cleared and the call rejects with an `InvalidTokenError`<!-- -->. The consumer must rebuild the `AppWebsocket` with a fresh token; further calls on this client will reject with `WebsocketClosedError`<!-- -->.
+
 **Signature:**
 
 ```typescript
@@ -52,4 +56,5 @@ The request to send over the websocket.
 
 Promise&lt;Response&gt;
 
+The decoded response payload.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,7 +943,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1094,7 +1093,6 @@
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -1166,7 +1164,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1410,7 +1407,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2206,7 +2202,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2267,7 +2262,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4167,7 +4161,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4201,7 +4194,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4955,7 +4947,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5137,7 +5128,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,6 +42,7 @@ export class WsClient extends Emittery {
   private pendingRequests: Record<number, HolochainRequest>;
   private index: number;
   private authenticationToken: AppAuthenticationToken | undefined;
+  private reconnectPromise: Promise<void> | undefined;
 
   constructor(socket: IsoWebSocket, url?: URL, options?: WsClientOptions) {
     super();
@@ -151,8 +152,21 @@ export class WsClient extends Emittery {
   /**
    * Send requests to the connected websocket.
    *
+   * If the underlying socket is closed when this method is called, the
+   * client transparently reconnects and re-authenticates using the cached
+   * token. Transient reconnect errors are surfaced as a `ConnectionError`
+   * and the cached token is retained, so a subsequent call can retry the
+   * reconnect.
+   *
+   * If the conductor rejects the cached token during the reconnect
+   * (signalled by an immediate close after the `authenticate` handshake),
+   * the cached token is cleared and the call rejects with an
+   * `InvalidTokenError`. The consumer must rebuild the `AppWebsocket`
+   * with a fresh token; further calls on this client will reject with
+   * `WebsocketClosedError`.
+   *
    * @param request - The request to send over the websocket.
-   * @returns
+   * @returns The decoded response payload.
    */
   async request<Response>(request: unknown): Promise<Response> {
     return this.exchange(request, this.sendMessage.bind(this));
@@ -172,7 +186,18 @@ export class WsClient extends Emittery {
       });
       return promise as Promise<Response>;
     } else if (this.url && this.authenticationToken) {
-      await this.reconnectWebsocket(this.url, this.authenticationToken);
+      // Dedupe concurrent reconnect attempts. The first caller into this
+      // branch starts a single reconnect; further callers await the same
+      // promise so we never create multiple sockets in parallel.
+      if (!this.reconnectPromise) {
+        this.reconnectPromise = this.reconnectWebsocket(
+          this.url,
+          this.authenticationToken,
+        ).finally(() => {
+          this.reconnectPromise = undefined;
+        });
+      }
+      await this.reconnectPromise;
       this.registerMessageListener(this.socket);
       this.registerCloseListener(this.socket);
       const promise = new Promise((resolve, reject) =>
@@ -295,11 +320,16 @@ export class WsClient extends Emittery {
   private async reconnectWebsocket(url: URL, token: AppAuthenticationToken) {
     return new Promise<void>((resolve, reject) => {
       this.socket = new IsoWebSocket(url, this.options);
+
+      // Track whether the "open" event has fired. The invalidTokenCloseListener
+      // must only clear the token when the connection did open and the conductor
+      // then closed it quickly.
+      let openFired = false;
+
       // This error event never occurs in tests. Could be removed?
       this.socket.addEventListener(
         "error",
         (errorEvent) => {
-          this.authenticationToken = undefined;
           reject(
             new HolochainError(
               "ConnectionError",
@@ -313,13 +343,22 @@ export class WsClient extends Emittery {
       const invalidTokenCloseListener = (
         closeEvent: IsoWebSocket.CloseEvent,
       ) => {
-        this.authenticationToken = undefined;
-        reject(
-          new HolochainError(
-            "InvalidTokenError",
-            `could not connect to ${this.url} due to an invalid app authentication token - close code ${closeEvent.code}`,
-          ),
-        );
+        if (openFired) {
+          this.authenticationToken = undefined;
+          reject(
+            new HolochainError(
+              "InvalidTokenError",
+              `could not connect to ${this.url} due to an invalid app authentication token - close code ${closeEvent.code}`,
+            ),
+          );
+        } else {
+          reject(
+            new HolochainError(
+              "ConnectionError",
+              `could not connect to Holochain Conductor API at ${url} - close code ${closeEvent.code}`,
+            ),
+          );
+        }
       };
       this.socket.addEventListener("close", invalidTokenCloseListener, {
         once: true,
@@ -328,6 +367,7 @@ export class WsClient extends Emittery {
       this.socket.addEventListener(
         "open",
         async () => {
+          openFired = true;
           const encodedMsg = encode({
             type: "authenticate",
             data: encode({ token }),

--- a/src/hdk/validation-receipts.ts
+++ b/src/hdk/validation-receipts.ts
@@ -1,4 +1,4 @@
-import { AgentPubKey, DhtOpHash, Timestamp } from "../types";
+import { AgentPubKey, DhtOpHash, Timestamp } from "../types.js";
 
 /**
  * @public

--- a/test/e2e/common.ts
+++ b/test/e2e/common.ts
@@ -195,6 +195,67 @@ export const withConductor =
     t.end();
   };
 
+/**
+ * A fully provisioned test app: an app websocket connected to a freshly
+ * installed app, plus the admin websocket and cell id used to set it up.
+ */
+export interface TestCase {
+  installed_app_id: InstalledAppId;
+  cell_id: CellId;
+  app_ws: AppWebsocket;
+  admin_ws: AdminWebsocket;
+}
+
+const WITH_APP_ADMIN_PORT = 33010;
+
+/**
+ * Spin up a dedicated conductor with the test app installed, run the provided
+ * function against it, then tear everything down. Mirrors `withConductor` but
+ * hands the test a ready-to-use {@link TestCase} instead of a bare conductor.
+ *
+ * @param f Function to call once the app is ready.
+ * @param singleUse Whether the app authentication token is single use.
+ * @param expirySeconds Expiry seconds of the app authentication token.
+ */
+export const withApp =
+  (
+    f: (testCase: TestCase) => Promise<void>,
+    singleUse?: boolean,
+    expirySeconds?: number,
+  ) =>
+  async () => {
+    const localServices = await runLocalServices();
+    const conductorProcess = await launch(
+      WITH_APP_ADMIN_PORT,
+      localServices.bootstrapServerUrl,
+      localServices.relayServerUrl,
+    );
+    try {
+      const { installed_app_id, cell_id, client, admin } =
+        await installAppAndDna(
+          WITH_APP_ADMIN_PORT,
+          singleUse,
+          expirySeconds,
+        );
+      await admin.authorizeSigningCredentials(cell_id);
+      await f({
+        installed_app_id,
+        cell_id,
+        app_ws: client,
+        admin_ws: admin,
+      });
+    } catch (e) {
+      console.error("Test caught exception: ", e);
+      throw e;
+    } finally {
+      await stopLocalServices(localServices.servicesProcess);
+      if (conductorProcess.pid && !conductorProcess.killed) {
+        process.kill(-conductorProcess.pid);
+      }
+      await cleanSandboxConductors();
+    }
+  };
+
 export const installAppAndDna = async (
   adminPort: number,
   /**

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -46,6 +46,7 @@ import {
   retryUntilTimeout,
   runLocalServices,
   stopLocalServices,
+  withApp,
   withConductor,
 } from "./common.js";
 
@@ -1610,6 +1611,54 @@ test(
       );
     }
   }),
+);
+
+test(
+  "app client recovers after a transient reconnect failure (regression #412)",
+  withApp(
+    async (testCase) => {
+      const { app_ws, cell_id } = testCase;
+
+      const callParams = {
+        cell_id,
+        zome_name: TEST_ZOME_NAME,
+        fn_name: "bar",
+        provenance: cell_id[1],
+        payload: null,
+      };
+
+      // Baseline: healthy call.
+      await app_ws.callZome(callParams);
+
+      // Induce a transient reconnect failure: point at a closed port and
+      // close the live socket. The next request reconnects to a bad URL,
+      // emits `error`, and (today) clears the auth token, wedging the client.
+      const goodUrl = app_ws.client.url!;
+      const badUrl = new URL("ws://127.0.0.1:1");
+      app_ws.client.url = badUrl;
+      await app_ws.client.close();
+
+      try {
+        await app_ws.callZome(callParams);
+        assert.fail("call against sabotaged URL should have failed");
+      } catch (error) {
+        assert(error instanceof HolochainError);
+        // Either ConnectionError or WebsocketClosedError is acceptable here;
+        // the point is the call failed transiently.
+      }
+
+      // Restore the good URL. Conductor is up, token must still be valid.
+      app_ws.client.url = goodUrl;
+
+      // With the fix, the next call should reconnect and succeed.
+      await app_ws.callZome(callParams);
+
+      // And a follow-up call must also succeed (no residual wedge).
+      await app_ws.callZome(callParams);
+    },
+    false,
+    0,
+  ),
 );
 
 test(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "module": "ES2022",
+    "module": "NodeNext",
     "target": "ES2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
@@ -10,7 +10,5 @@
     "strict": true,
     "typeRoots": ["./node_modules/@types", "./typings"]
   },
-  "include": [
-    "./src/**/*", "./typings"
-  ],
+  "include": ["./src/**/*", "./typings"]
 }


### PR DESCRIPTION
Backport of #414

### TODO:
- [x] CHANGELOG mentions all code changes.
- [ ] docs have been updated (`npm run build:docs`)
