### PR TITLE
feat: route the App API over Tauri IPC for in-process plugin webviews

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run tests
         run: nix develop -c $SHELL -c "npm t"
 
+      - name: Run Tauri transport unit tests
+        run: nix develop -c $SHELL -c "npm run test:tauri"
+
       - name: Run doc test of app websocket
         run: nix develop -c $SHELL -c "./doc-test-app-ws.sh"
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ setSigningCredentials(cell_id, signingCredentials);
 localStorage.setItem(cellIdB64, JSON.stringify(signingCredentials));
 ```
 
+### Connecting from a Tauri app with an in-process conductor
+
+When the UI runs inside a Tauri webview served by [`tauri-plugin-holochain`](https://github.com/holochain/android-service-runtime) — which runs the conductor in the same process — `AppWebsocket.connect` automatically routes the App API through Tauri IPC instead of opening a websocket. No code change is required:
+
+```typescript
+// Inside a tauri-plugin-holochain webview, this returns an AppWebsocket backed
+// by a TauriAppTransport rather than a WsClient. callZome, appInfo, signals,
+// clone cells, etc. all work unchanged.
+const appWs = await AppWebsocket.connect();
+```
+
+The plugin injects a `__HC_TAURI_HOLOCHAIN__` marker on `window`; `isTauriHolochain()` detects it and `connect()` constructs a `TauriAppTransport` that moves the same msgpack `{ type, value }` payloads a websocket would carry over the `plugin:holochain|app_request` command.
+
+**Trust model.** The websocket path is scoped by a per-app auth token. The Tauri path replaces that with two guarantees enforced on the Rust side: the conductor derives the app id from the **calling window's label** (never from a JS-supplied argument), and Tauri's capability/permission system gates the `app_request` command to the intended windows. Zome calls are still signed by the in-process keystore via the host signer, so no signing key is exposed to the webview. The websocket transport is unchanged and remains the path for the separated client + service deployment and any non-Tauri consumer.
+
 ## Running tests
 
 You need a version (`stable` toolchain) of Rust available.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:tauri": "tsx test/tauri.ts",
     "test": "RUST_LOG=error RUST_BACKTRACE=1 tsx test/index.ts",
     "build:lib": "rimraf ./lib && tsc -p tsconfig.build.json",
+    "prepare": "npm run build:lib",
     "build:docs": "api-extractor run --local && api-documenter markdown -i docs/temp -o docs",
     "build": "npm run build:lib && npm run build:docs",
     "prepublishOnly": "npm run lint && npm run build"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "test:app-agent": "RUST_LOG=error RUST_BACKTRACE=1 tsx test/e2e/app-websocket.ts",
     "test:utils": "RUST_LOG=error RUST_BACKTRACE=1 tsx test/e2e/utils.ts",
+    "test:tauri": "tsx test/tauri.ts",
     "test": "RUST_LOG=error RUST_BACKTRACE=1 tsx test/index.ts",
     "build:lib": "rimraf ./lib && tsc -p tsconfig.build.json",
     "build:docs": "api-extractor run --local && api-documenter markdown -i docs/temp -o docs",

--- a/src/api/app/decode.ts
+++ b/src/api/app/decode.ts
@@ -1,0 +1,80 @@
+import { decode } from "@msgpack/msgpack";
+import { encodeHashToBase64 } from "../../utils/base64.js";
+import { HolochainError } from "../common.js";
+import { AppSignal, RawSignal, Signal, SignalType } from "./types.js";
+
+/**
+ * Convert msgpack map keys the way Holochain conductor responses require:
+ * string and number keys pass through, byte-array keys are HoloHashes and are
+ * returned in their Base64 string form. Shared by every transport
+ * ({@link WsClient} and {@link TauriAppTransport}) so decoded responses match
+ * byte for byte regardless of pipe.
+ *
+ * @internal
+ */
+export const holoHashMapKeyConverter = (key: unknown) => {
+  if (typeof key === "string" || typeof key === "number") {
+    return key;
+  }
+  if (key && typeof key === "object" && key instanceof Uint8Array) {
+    // Key of type byte array, must be a HoloHash.
+    return encodeHashToBase64(key);
+  }
+  throw new HolochainError(
+    "DeserializationError",
+    "Encountered map with key of type 'object', but not HoloHash " + key,
+  );
+};
+
+/**
+ * Validate that a decoded value is a well-formed Holochain signal.
+ *
+ * @internal
+ */
+export function assertHolochainSignal(
+  signal: unknown,
+): asserts signal is RawSignal {
+  if (
+    typeof signal === "object" &&
+    signal !== null &&
+    "type" in signal &&
+    "value" in signal &&
+    [SignalType.App, SignalType.System].some((type) => signal.type === type)
+  ) {
+    return;
+  }
+  throw new HolochainError(
+    "UnknownSignalFormat",
+    `incoming signal has unknown signal format ${JSON.stringify(
+      signal,
+      null,
+      4,
+    )}`,
+  );
+}
+
+/**
+ * Turn an already-decoded raw signal into the {@link Signal} surfaced to
+ * callers: system signals pass through; app signals have their inner payload
+ * decoded. Shared by every transport so signal handling is identical whether
+ * the bytes arrive over a websocket or Tauri IPC.
+ *
+ * @internal
+ */
+export function decodeSignal(rawSignal: unknown): Signal {
+  assertHolochainSignal(rawSignal);
+
+  if (rawSignal.type === SignalType.System) {
+    return { type: SignalType.System, value: rawSignal.value } as Signal;
+  }
+
+  const encodedAppSignal = rawSignal.value;
+  // In order to return readable content to the UI, the signal payload must also
+  // be deserialized.
+  const signal: AppSignal = {
+    cell_id: encodedAppSignal.cell_id,
+    zome_name: encodedAppSignal.zome_name,
+    payload: decode(encodedAppSignal.signal),
+  };
+  return { type: SignalType.App, value: signal } as Signal;
+}

--- a/src/api/app/index.ts
+++ b/src/api/app/index.ts
@@ -1,2 +1,3 @@
+export * from "./tauri-transport.js";
 export * from "./types.js";
 export * from "./websocket.js";

--- a/src/api/app/tauri-transport.ts
+++ b/src/api/app/tauri-transport.ts
@@ -1,9 +1,18 @@
 import { decode, encode } from "@msgpack/msgpack";
 import Emittery from "emittery";
-import { getTauriInvoke } from "../../environments/tauri.js";
+import {
+  getTauriHolochainEnvironment,
+  getTauriInvoke,
+} from "../../environments/tauri.js";
 import { encodeHashToBase64 } from "../../utils/base64.js";
 import { HolochainError } from "../common.js";
-import { AppClientTransport } from "./types.js";
+import {
+  AppClientTransport,
+  AppSignal,
+  RawSignal,
+  Signal,
+  SignalType,
+} from "./types.js";
 
 /**
  * Carries the App API over Tauri IPC into a Holochain conductor running in the
@@ -21,10 +30,50 @@ import { AppClientTransport } from "./types.js";
  */
 export class TauriAppTransport extends Emittery implements AppClientTransport {
   private readonly command: string;
+  private readonly unsubscribeSignals?: () => void;
 
   constructor(pluginName: string) {
     super();
     this.command = `plugin:${pluginName}|app_request`;
+
+    // Subscribe to the plugin's signal bridge (if injected) and re-emit each
+    // signal on this Emittery, so `AppWebsocket.on("signal", ...)` works exactly
+    // as it does over a websocket.
+    const env = getTauriHolochainEnvironment();
+    this.unsubscribeSignals = env?.subscribeSignals?.((bytes) =>
+      this.handleSignalBytes(bytes),
+    );
+  }
+
+  /** Stop receiving signals. */
+  close() {
+    this.unsubscribeSignals?.();
+  }
+
+  /**
+   * Decode a signal delivered by the plugin and emit it. The bytes are the same
+   * the websocket carries, so this mirrors `WsClient`'s signal handling
+   * (src/api/client.ts): app signals have their inner payload decoded; system
+   * signals pass through.
+   */
+  private handleSignalBytes(bytes: Uint8Array) {
+    const raw = decode(bytes) as RawSignal;
+    if (raw.type === SignalType.System) {
+      this.emit("signal", { type: SignalType.System, value: raw.value }).catch(
+        console.error,
+      );
+      return;
+    }
+    const encodedAppSignal = raw.value;
+    const signal: AppSignal = {
+      cell_id: encodedAppSignal.cell_id,
+      zome_name: encodedAppSignal.zome_name,
+      payload: decode(encodedAppSignal.signal),
+    };
+    this.emit("signal", {
+      type: SignalType.App,
+      value: signal,
+    } as Signal).catch(console.error);
   }
 
   /**

--- a/src/api/app/tauri-transport.ts
+++ b/src/api/app/tauri-transport.ts
@@ -1,0 +1,66 @@
+import { decode, encode } from "@msgpack/msgpack";
+import Emittery from "emittery";
+import { getTauriInvoke } from "../../environments/tauri.js";
+import { encodeHashToBase64 } from "../../utils/base64.js";
+import { HolochainError } from "../common.js";
+import { AppClientTransport } from "./types.js";
+
+/**
+ * Carries the App API over Tauri IPC into a Holochain conductor running in the
+ * same process, instead of over a websocket.
+ *
+ * From {@link AppWebsocket}'s perspective this is a drop-in for
+ * {@link WsClient}: it exposes the same `request` method and is an Emittery
+ * that emits `signal` events, so every AppWebsocket method works unchanged.
+ * Only the pipe differs — the same msgpack-encoded `{ type, value }` payloads a
+ * websocket would carry are sent through the `plugin:<name>|app_request`
+ * command. No app id is sent: the conductor scopes each request to the calling
+ * window on the Rust side, which replaces the per-app websocket auth token.
+ *
+ * @public
+ */
+export class TauriAppTransport extends Emittery implements AppClientTransport {
+  private readonly command: string;
+
+  constructor(pluginName: string) {
+    super();
+    this.command = `plugin:${pluginName}|app_request`;
+  }
+
+  /**
+   * Send a tagged App API request through Tauri IPC and return the tagged
+   * response. The bytes on the wire are identical to the websocket path.
+   *
+   * @param request - The tagged `{ type, value }` App API request.
+   * @returns The decoded tagged App API response.
+   */
+  async request<Response>(request: unknown): Promise<Response> {
+    const invoke = getTauriInvoke();
+    const requestBytes = Array.from(encode(request));
+    const responseBytes = await invoke<number[]>(this.command, {
+      request: requestBytes,
+    });
+    return decode(Uint8Array.from(responseBytes), {
+      mapKeyConverter,
+    }) as Response;
+  }
+}
+
+/**
+ * Convert msgpack map keys exactly as the websocket client does: byte-array
+ * keys are HoloHashes and are returned in their Base64 string form. Mirrors the
+ * converter in `WsClient.handleResponse` (src/api/client.ts) so decoded
+ * responses match the websocket path byte for byte.
+ */
+const mapKeyConverter = (key: unknown) => {
+  if (typeof key === "string" || typeof key === "number") {
+    return key;
+  }
+  if (key && typeof key === "object" && key instanceof Uint8Array) {
+    return encodeHashToBase64(key);
+  }
+  throw new HolochainError(
+    "DeserializationError",
+    "Encountered map with key of type 'object', but not HoloHash " + key,
+  );
+};

--- a/src/api/app/tauri-transport.ts
+++ b/src/api/app/tauri-transport.ts
@@ -4,15 +4,8 @@ import {
   getTauriHolochainEnvironment,
   getTauriInvoke,
 } from "../../environments/tauri.js";
-import { encodeHashToBase64 } from "../../utils/base64.js";
-import { HolochainError } from "../common.js";
-import {
-  AppClientTransport,
-  AppSignal,
-  RawSignal,
-  Signal,
-  SignalType,
-} from "./types.js";
+import { decodeSignal, holoHashMapKeyConverter } from "./decode.js";
+import { AppClientTransport } from "./types.js";
 
 /**
  * Carries the App API over Tauri IPC into a Holochain conductor running in the
@@ -45,35 +38,28 @@ export class TauriAppTransport extends Emittery implements AppClientTransport {
     );
   }
 
-  /** Stop receiving signals. */
+  /**
+   * Stop receiving signals.
+   *
+   * Not reachable through {@link AppClientTransport} (the public transport
+   * surface is `request` + `on`), and {@link AppWebsocket} exposes no app-level
+   * disconnect — same as the websocket path. In practice the subscription lives
+   * for the lifetime of the webview. This is kept for explicit teardown in
+   * tests and any future wiring of a disconnect through the interface.
+   */
   close() {
     this.unsubscribeSignals?.();
   }
 
   /**
    * Decode a signal delivered by the plugin and emit it. The bytes are the same
-   * the websocket carries, so this mirrors `WsClient`'s signal handling
-   * (src/api/client.ts): app signals have their inner payload decoded; system
-   * signals pass through.
+   * the websocket carries, so this reuses the shared `decodeSignal` helper
+   * (src/api/app/decode.ts): app signals have their inner payload decoded;
+   * system signals pass through. Malformed signals throw, exactly as on the
+   * websocket path.
    */
   private handleSignalBytes(bytes: Uint8Array) {
-    const raw = decode(bytes) as RawSignal;
-    if (raw.type === SignalType.System) {
-      this.emit("signal", { type: SignalType.System, value: raw.value }).catch(
-        console.error,
-      );
-      return;
-    }
-    const encodedAppSignal = raw.value;
-    const signal: AppSignal = {
-      cell_id: encodedAppSignal.cell_id,
-      zome_name: encodedAppSignal.zome_name,
-      payload: decode(encodedAppSignal.signal),
-    };
-    this.emit("signal", {
-      type: SignalType.App,
-      value: signal,
-    } as Signal).catch(console.error);
+    this.emit("signal", decodeSignal(decode(bytes))).catch(console.error);
   }
 
   /**
@@ -90,26 +76,7 @@ export class TauriAppTransport extends Emittery implements AppClientTransport {
       request: requestBytes,
     });
     return decode(Uint8Array.from(responseBytes), {
-      mapKeyConverter,
+      mapKeyConverter: holoHashMapKeyConverter,
     }) as Response;
   }
 }
-
-/**
- * Convert msgpack map keys exactly as the websocket client does: byte-array
- * keys are HoloHashes and are returned in their Base64 string form. Mirrors the
- * converter in `WsClient.handleResponse` (src/api/client.ts) so decoded
- * responses match the websocket path byte for byte.
- */
-const mapKeyConverter = (key: unknown) => {
-  if (typeof key === "string" || typeof key === "number") {
-    return key;
-  }
-  if (key && typeof key === "object" && key instanceof Uint8Array) {
-    return encodeHashToBase64(key);
-  }
-  throw new HolochainError(
-    "DeserializationError",
-    "Encountered map with key of type 'object', but not HoloHash " + key,
-  );
-};

--- a/src/api/app/types.ts
+++ b/src/api/app/types.ts
@@ -501,6 +501,19 @@ export interface AppClient {
 }
 
 /**
+ * The transport an {@link AppClient} uses to reach the conductor: either a
+ * websocket (`WsClient`) or Tauri IPC ({@link TauriAppTransport}). It must
+ * carry tagged App API requests and surface `signal` events. This is the only
+ * surface {@link AppWebsocket} needs from its transport.
+ *
+ * @public
+ */
+export interface AppClientTransport {
+  request<Response>(request: unknown): Promise<Response>;
+  on(eventName: "signal", listener: SignalCb): UnsubscribeFunction;
+}
+
+/**
  * @public
  */
 export interface AppWebsocketConnectionOptions extends WebsocketConnectionOptions {

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -7,6 +7,11 @@ import {
   getHostZomeCallSigner,
   getLauncherEnvironment,
 } from "../../environments/launcher.js";
+import {
+  getTauriHolochainEnvironment,
+  isTauriHolochain,
+} from "../../environments/tauri.js";
+import { TauriAppTransport } from "./tauri-transport.js";
 import { AgentPubKey, InstalledAppId, RoleName } from "../../types.js";
 import { encodeHashToBase64 } from "../../utils/index.js";
 import {
@@ -43,6 +48,7 @@ import {
   AbandonCountersigningSessionStateRequest,
   AbandonCountersigningSessionStateResponse,
   AppClient,
+  AppClientTransport,
   AppEvents,
   AppInfoResponse,
   AppWebsocketConnectionOptions,
@@ -77,7 +83,7 @@ import {
  * @public
  */
 export class AppWebsocket implements AppClient {
-  readonly client: WsClient;
+  readonly client: AppClientTransport;
   readonly myPubKey: AgentPubKey;
   readonly installedAppId: InstalledAppId;
   private readonly defaultTimeout: number;
@@ -143,7 +149,7 @@ export class AppWebsocket implements AppClient {
   >;
 
   private constructor(
-    client: WsClient,
+    client: AppClientTransport,
     appInfo: AppInfo,
     callZomeTransform?: CallZomeTransform,
     defaultTimeout?: number,
@@ -252,6 +258,38 @@ export class AppWebsocket implements AppClient {
    * @returns A new instance of an AppWebsocket.
    */
   static async connect(options: AppWebsocketConnectionOptions = {}) {
+    // In a Tauri webview wired to an in-process conductor, reach the App API
+    // through Tauri IPC instead of a websocket. The conductor is in the same
+    // process, so there is no port to dial and no token to authenticate — the
+    // request is scoped to this window on the Rust side.
+    if (isTauriHolochain()) {
+      const tauriEnv = getTauriHolochainEnvironment();
+      const client = new TauriAppTransport(
+        tauriEnv?.PLUGIN_NAME ?? "holochain",
+      );
+
+      const appInfo = await (
+        AppWebsocket.requester(
+          client,
+          "app_info",
+          options.defaultTimeout ?? DEFAULT_TIMEOUT,
+        ) as Requester<null, AppInfoResponse>
+      )(null);
+      if (!appInfo) {
+        throw new HolochainError(
+          "AppNotFound",
+          `The app this Tauri webview is bound to was not found. The app needs to be installed and enabled.`,
+        );
+      }
+
+      return new AppWebsocket(
+        client,
+        appInfo,
+        options.callZomeTransform,
+        options.defaultTimeout,
+      );
+    }
+
     // Check if we are in the launcher's environment, and if so, redirect the url to connect to
     const env = getLauncherEnvironment();
 
@@ -607,7 +645,7 @@ export class AppWebsocket implements AppClient {
   }
 
   private static requester<ReqI, ReqO, ResI, ResO>(
-    client: WsClient,
+    client: AppClientTransport,
     tag: string,
     defaultTimeout: number,
     transformer?: Transformer<ReqI, ReqO, ResI, ResO>,

--- a/src/api/app/websocket.ts
+++ b/src/api/app/websocket.ts
@@ -254,6 +254,11 @@ export class AppWebsocket implements AppClient {
   /**
    * Instance factory for creating an {@link AppWebsocket}.
    *
+   * Note: in a Tauri webview wired to an in-process conductor
+   * ({@link isTauriHolochain}), the App API is transparently routed over Tauri
+   * IPC and `options.url` and `options.token` are ignored — there is no port to
+   * dial and no token to authenticate. Pass them only for the websocket path.
+   *
    * @param options - {@link (WebsocketConnectionOptions:interface)}
    * @returns A new instance of an AppWebsocket.
    */
@@ -261,7 +266,8 @@ export class AppWebsocket implements AppClient {
     // In a Tauri webview wired to an in-process conductor, reach the App API
     // through Tauri IPC instead of a websocket. The conductor is in the same
     // process, so there is no port to dial and no token to authenticate — the
-    // request is scoped to this window on the Rust side.
+    // request is scoped to this window on the Rust side. Any options.url /
+    // options.token a caller passed are intentionally ignored here.
     if (isTauriHolochain()) {
       const tauriEnv = getTauriHolochainEnvironment();
       const client = new TauriAppTransport(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,8 +3,10 @@ import Emittery from "emittery";
 import IsoWebSocket from "isomorphic-ws";
 import { HolochainError, WsClientOptions } from "./common.js";
 import { AppAuthenticationToken } from "./admin/index.js";
-import { AppSignal, RawSignal, Signal, SignalType } from "./app/index.js";
-import { encodeHashToBase64 } from "../utils/base64.js";
+import {
+  decodeSignal,
+  holoHashMapKeyConverter,
+} from "./app/decode.js";
 
 interface HolochainMessage {
   id: number;
@@ -260,30 +262,7 @@ export class WsClient extends Emittery {
             "incoming signal has no data",
           );
         }
-        const deserializedSignal = decode(message.data);
-        assertHolochainSignal(deserializedSignal);
-
-        if (deserializedSignal.type === SignalType.System) {
-          this.emit("signal", {
-            type: SignalType.System,
-            value: deserializedSignal.value,
-          } as Signal);
-        } else {
-          const encodedAppSignal = deserializedSignal.value;
-
-          // In order to return readable content to the UI, the signal payload must also be deserialized.
-          const payload = decode(encodedAppSignal.signal);
-
-          const signal: AppSignal = {
-            cell_id: encodedAppSignal.cell_id,
-            zome_name: encodedAppSignal.zome_name,
-            payload,
-          };
-          this.emit("signal", {
-            type: SignalType.App,
-            value: signal,
-          } as Signal);
-        }
+        this.emit("signal", decodeSignal(decode(message.data)));
       } else if (message.type === "response") {
         this.handleResponse(message);
       } else {
@@ -393,22 +372,7 @@ export class WsClient extends Emittery {
         );
       } else {
         this.pendingRequests[id].resolve(
-          decode(msg.data, {
-            mapKeyConverter: (key: unknown) => {
-              if (typeof key === "string" || typeof key === "number") {
-                return key;
-              }
-              if (key && typeof key === "object" && key instanceof Uint8Array) {
-                // Key of type byte array, must be a HoloHash.
-                return encodeHashToBase64(key);
-              }
-              throw new HolochainError(
-                "DeserializationError",
-                "Encountered map with key of type 'object', but not HoloHash " +
-                  key,
-              );
-            },
-          }),
+          decode(msg.data, { mapKeyConverter: holoHashMapKeyConverter }),
         );
       }
       delete this.pendingRequests[id];
@@ -435,26 +399,6 @@ function assertHolochainMessage(
     "UnknownMessageFormat",
     `incoming message has unknown message format ${JSON.stringify(
       message,
-      null,
-      4,
-    )}`,
-  );
-}
-
-function assertHolochainSignal(signal: unknown): asserts signal is RawSignal {
-  if (
-    typeof signal === "object" &&
-    signal !== null &&
-    "type" in signal &&
-    "value" in signal &&
-    [SignalType.App, SignalType.System].some((type) => signal.type === type)
-  ) {
-    return;
-  }
-  throw new HolochainError(
-    "UnknownSignalFormat",
-    `incoming signal has unknown signal format ${JSON.stringify(
-      signal,
       null,
       4,
     )}`,

--- a/src/environments/tauri.ts
+++ b/src/environments/tauri.ts
@@ -69,6 +69,8 @@ export const getTauriHolochainEnvironment = ():
 /**
  * Get Tauri's `invoke` from the webview, bound to its IPC bridge. Throws a
  * {@link HolochainError} if the Tauri IPC bridge is not present.
+ *
+ * @public
  */
 export const getTauriInvoke = (): TauriInvokeFn => {
   const internals = globalThis.window?.[__TAURI_INTERNALS__];

--- a/src/environments/tauri.ts
+++ b/src/environments/tauri.ts
@@ -1,0 +1,79 @@
+import { HolochainError } from "../api/common.js";
+import { InstalledAppId } from "../types.js";
+
+/**
+ * Environment injected by the in-process Tauri plugin (tauri-plugin-holochain)
+ * into a webview that is wired to a Holochain conductor running in the same
+ * process. Its presence signals that the App API should be reached through
+ * Tauri IPC rather than by opening a websocket.
+ *
+ * @public
+ */
+export interface TauriHolochainEnvironment {
+  /** The app this webview is bound to. */
+  INSTALLED_APP_ID: InstalledAppId;
+  /**
+   * The Tauri plugin name used to build the IPC command name. Defaults to
+   * `"holochain"` when not provided.
+   */
+  PLUGIN_NAME?: string;
+}
+
+/**
+ * The slice of Tauri's internal IPC bridge this client uses: the `invoke`
+ * function.
+ *
+ * @public
+ */
+export type TauriInvokeFn = <T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+const __HC_TAURI_HOLOCHAIN__ = "__HC_TAURI_HOLOCHAIN__";
+const __TAURI_INTERNALS__ = "__TAURI_INTERNALS__";
+
+/**
+ * Whether the code is running inside a Tauri webview opened by
+ * tauri-plugin-holochain. True only when both the Tauri IPC bridge and the
+ * plugin's holochain marker are present on `window`.
+ *
+ * @public
+ */
+export const isTauriHolochain = (): boolean =>
+  !!globalThis.window &&
+  __HC_TAURI_HOLOCHAIN__ in globalThis.window &&
+  __TAURI_INTERNALS__ in globalThis.window;
+
+/**
+ * The injected {@link TauriHolochainEnvironment}, or `undefined` when not in a
+ * Tauri holochain webview.
+ *
+ * @public
+ */
+export const getTauriHolochainEnvironment = ():
+  | TauriHolochainEnvironment
+  | undefined =>
+  isTauriHolochain() ? globalThis.window[__HC_TAURI_HOLOCHAIN__] : undefined;
+
+/**
+ * Get Tauri's `invoke` from the webview, bound to its IPC bridge. Throws a
+ * {@link HolochainError} if the Tauri IPC bridge is not present.
+ */
+export const getTauriInvoke = (): TauriInvokeFn => {
+  const internals = globalThis.window?.[__TAURI_INTERNALS__];
+  if (!internals) {
+    throw new HolochainError(
+      "TauriInternalsMissing",
+      "not running in a Tauri webview - window.__TAURI_INTERNALS__ is not available",
+    );
+  }
+  return internals.invoke.bind(internals);
+};
+
+declare global {
+  interface Window {
+    [__HC_TAURI_HOLOCHAIN__]?: TauriHolochainEnvironment;
+    [__TAURI_INTERNALS__]?: { invoke: TauriInvokeFn };
+  }
+}

--- a/src/environments/tauri.ts
+++ b/src/environments/tauri.ts
@@ -33,7 +33,7 @@ export interface TauriHolochainEnvironment {
  * The slice of Tauri's internal IPC bridge this client uses: the `invoke`
  * function.
  *
- * @public
+ * @internal
  */
 export type TauriInvokeFn = <T>(
   cmd: string,
@@ -70,7 +70,10 @@ export const getTauriHolochainEnvironment = ():
  * Get Tauri's `invoke` from the webview, bound to its IPC bridge. Throws a
  * {@link HolochainError} if the Tauri IPC bridge is not present.
  *
- * @public
+ * Internal to the transport; not part of the package's public API (it is not
+ * re-exported from index.ts).
+ *
+ * @internal
  */
 export const getTauriInvoke = (): TauriInvokeFn => {
   const internals = globalThis.window?.[__TAURI_INTERNALS__];

--- a/src/environments/tauri.ts
+++ b/src/environments/tauri.ts
@@ -17,6 +17,16 @@ export interface TauriHolochainEnvironment {
    * `"holochain"` when not provided.
    */
   PLUGIN_NAME?: string;
+  /**
+   * Subscribe to the conductor's signal stream for this window, provided by the
+   * plugin's injected env (it bridges the plugin's Tauri signal events). The
+   * callback receives each signal as the msgpack bytes the app websocket would
+   * have carried. Returns a function that unsubscribes.
+   *
+   * Absent when the plugin injects no signal bridge; the transport then simply
+   * delivers no signals.
+   */
+  subscribeSignals?: (cb: (bytes: Uint8Array) => void) => () => void;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export * from "./api/index.js";
-export * from "./environments/tauri.js";
+// Only the environment-detection surface is public. getTauriInvoke /
+// TauriInvokeFn are transport-internal (used by TauriAppTransport) and are
+// deliberately not re-exported, so they stay out of the package's semver
+// contract.
+export {
+  isTauriHolochain,
+  getTauriHolochainEnvironment,
+} from "./environments/tauri.js";
+export type { TauriHolochainEnvironment } from "./environments/tauri.js";
 export * from "./hdk/index.js";
 export * from "./types.js";
 export * from "./utils/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./api/index.js";
+export * from "./environments/tauri.js";
 export * from "./hdk/index.js";
 export * from "./types.js";
 export * from "./utils/index.js";

--- a/test/tauri.ts
+++ b/test/tauri.ts
@@ -293,3 +293,134 @@ test("TauriAppTransport delivers app signals from the plugin's signal bridge", a
     "inner app signal payload decoded",
   );
 });
+
+test("TauriAppTransport passes system signals through unchanged", async (t) => {
+  let captured: ((bytes: Uint8Array) => void) | undefined;
+  const systemValue = { Activity: { agent: "alice" } };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: {
+      INSTALLED_APP_ID: "my-app",
+      subscribeSignals: (cb: (bytes: Uint8Array) => void) => {
+        captured = cb;
+        return () => {};
+      },
+    },
+    __TAURI_INTERNALS__: { invoke: async () => [] },
+  };
+
+  const transport = new TauriAppTransport("holochain");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const received: any[] = [];
+  transport.on("signal", (s) => received.push(s));
+
+  // A system signal carries no inner app payload: { type: "system", value }.
+  captured!(encode({ type: "system", value: systemValue }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  t.equal(received.length, 1, "one signal was emitted");
+  t.equal(received[0].type, "system", "emitted as a system signal");
+  t.deepEqual(
+    received[0].value,
+    systemValue,
+    "system signal value passed through unchanged, not decoded as an app signal",
+  );
+});
+
+test("AppWebsocket.connect rejects with a HolochainError when app_info returns an error response", async (t) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: { INSTALLED_APP_ID: "my-app" },
+    __TAURI_INTERNALS__: {
+      // The conductor's tagged error response: { type: "error", value: { type, value } }.
+      invoke: async () =>
+        Array.from(
+          encode({
+            type: "error",
+            value: { type: "ribosome_error", value: "boom" },
+          }),
+        ),
+    },
+  };
+
+  try {
+    await AppWebsocket.connect();
+    t.fail("connect should have rejected on an error response");
+  } catch (err) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = err as any;
+    t.equal(
+      e.name,
+      "ribosome_error",
+      "catchError turns the error response into a HolochainError with the response's error type",
+    );
+    t.equal(e.message, "boom", "the error value becomes the message");
+  }
+});
+
+test("AppWebsocket.connect throws AppNotFound when app_info is empty", async (t) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: { INSTALLED_APP_ID: "my-app" },
+    __TAURI_INTERNALS__: {
+      invoke: async () => Array.from(encode({ type: "app_info", value: null })),
+    },
+  };
+
+  try {
+    await AppWebsocket.connect();
+    t.fail("connect should have rejected when no app is bound");
+  } catch (err) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    t.equal(
+      (err as any).name,
+      "AppNotFound",
+      "throws AppNotFound when app_info returns no app",
+    );
+  }
+});
+
+test("TauriAppTransport.request throws TauriInternalsMissing without the Tauri bridge", async (t) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {}; // no __TAURI_INTERNALS__
+
+  const transport = new TauriAppTransport("holochain");
+  try {
+    await transport.request({ type: "app_info", value: null });
+    t.fail("request should have thrown without the Tauri IPC bridge");
+  } catch (err) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    t.equal(
+      (err as any).name,
+      "TauriInternalsMissing",
+      "request throws when window.__TAURI_INTERNALS__ is absent",
+    );
+  }
+});
+
+test("TauriAppTransport.close unsubscribes from the signal bridge", (t) => {
+  let unsubscribed = false;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: {
+      INSTALLED_APP_ID: "my-app",
+      subscribeSignals: () => () => {
+        unsubscribed = true;
+      },
+    },
+    __TAURI_INTERNALS__: { invoke: async () => [] },
+  };
+
+  const transport = new TauriAppTransport("holochain");
+  t.notOk(unsubscribed, "not unsubscribed before close()");
+  transport.close();
+  t.ok(unsubscribed, "close() invokes the bridge's unsubscribe function");
+  t.end();
+});

--- a/test/tauri.ts
+++ b/test/tauri.ts
@@ -245,3 +245,51 @@ test("AppWebsocket.callZome signs with the host signer and routes the call over 
   t.ok(callZomeSeen, "a call_zome request was sent over Tauri IPC");
   t.deepEqual(result, zomeResult, "the zome response was decoded and returned");
 });
+
+test("TauriAppTransport delivers app signals from the plugin's signal bridge", async (t) => {
+  let captured: ((bytes: Uint8Array) => void) | undefined;
+  const cellId = [fakeHash(1), fakeHash(2)];
+  const zomeName = "posts";
+  const payload = { EntryCreated: { hash: "abc" } };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: {
+      INSTALLED_APP_ID: "my-app",
+      subscribeSignals: (cb: (bytes: Uint8Array) => void) => {
+        captured = cb;
+        return () => {};
+      },
+    },
+    __TAURI_INTERNALS__: { invoke: async () => [] },
+  };
+
+  const transport = new TauriAppTransport("holochain");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const received: any[] = [];
+  transport.on("signal", (s) => received.push(s));
+
+  t.ok(captured, "transport subscribed to the plugin signal bridge");
+
+  // The bytes the plugin forwards are the msgpack of holochain's Signal:
+  // { type: "app", value: { cell_id, zome_name, signal: <encoded payload> } }.
+  const rawSignal = {
+    type: "app",
+    value: { cell_id: cellId, zome_name: zomeName, signal: encode(payload) },
+  };
+  captured!(encode(rawSignal));
+
+  // Emittery delivers on a microtask.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  t.equal(received.length, 1, "one signal was emitted");
+  t.equal(received[0].type, "app", "emitted as an app signal");
+  t.equal(received[0].value.zome_name, zomeName, "zome name preserved");
+  t.deepEqual(
+    received[0].value.payload,
+    payload,
+    "inner app signal payload decoded",
+  );
+});

--- a/test/tauri.ts
+++ b/test/tauri.ts
@@ -1,0 +1,247 @@
+import { decode, encode } from "@msgpack/msgpack";
+import test from "tape";
+import {
+  AppWebsocket,
+  encodeHashToBase64,
+  getTauriHolochainEnvironment,
+  isTauriHolochain,
+  TauriAppTransport,
+} from "../src/index.js";
+
+// These are pure unit tests: they mock Tauri's `window.__TAURI_INTERNALS__.invoke`
+// and never open a websocket or start a conductor. They lock in the contract
+// between the JS transport and the plugin's `app_request` command — that the
+// same msgpack `{ type, value }` payloads the websocket carries are moved over
+// Tauri IPC instead.
+
+// A throwaway 39-byte value standing in for a HoloHash.
+const fakeHash = (fill: number) => Uint8Array.from(new Array(39).fill(fill));
+
+// Minimal msgpack encoders for hand-crafting a map with a *binary* key, the
+// way Rust (rmp) serializes a HashMap keyed by a HoloHash. @msgpack/msgpack's
+// encode() cannot produce a binary-keyed map from JS (a JS Map serializes as
+// empty), so we build the bytes directly.
+const mpStr = (s: string) => {
+  const b = Array.from(new TextEncoder().encode(s));
+  return [0xa0 | b.length, ...b]; // fixstr, len < 32
+};
+const mpBin = (b: Uint8Array) => [0xc4, b.length, ...Array.from(b)]; // bin8, len < 256
+
+test("isTauriHolochain detects the plugin webview environment", (t) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {};
+  t.notOk(isTauriHolochain(), "false with no markers");
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window.__TAURI_INTERNALS__ = { invoke: async () => [] };
+  t.notOk(isTauriHolochain(), "false with only the Tauri bridge");
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window.__HC_TAURI_HOLOCHAIN__ = { INSTALLED_APP_ID: "my-app" };
+  t.ok(
+    isTauriHolochain(),
+    "true with both the bridge and the holochain marker",
+  );
+  t.equal(
+    getTauriHolochainEnvironment()?.INSTALLED_APP_ID,
+    "my-app",
+    "exposes the injected environment",
+  );
+
+  t.end();
+});
+
+test("TauriAppTransport.request encodes the request, invokes the plugin command, and decodes the response", async (t) => {
+  let capturedCmd: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let capturedArgs: any;
+  const responseTagged = {
+    type: "app_info",
+    value: { installed_app_id: "my-app" },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invoke: async (cmd: string, args: any) => {
+        capturedCmd = cmd;
+        capturedArgs = args;
+        return Array.from(encode(responseTagged));
+      },
+    },
+  };
+
+  const transport = new TauriAppTransport("holochain");
+  const requestTagged = { type: "app_info", value: null };
+  const result = await transport.request(requestTagged);
+
+  t.equal(
+    capturedCmd,
+    "plugin:holochain|app_request",
+    "calls the plugin's app_request command",
+  );
+  t.ok(Array.isArray(capturedArgs.request), "request is sent as a byte array");
+  t.notOk(
+    "appId" in capturedArgs,
+    "no app id is sent — the conductor scopes the request to the window",
+  );
+  t.deepEqual(
+    decode(Uint8Array.from(capturedArgs.request)),
+    requestTagged,
+    "the bytes on the wire are the msgpack of the tagged request",
+  );
+  t.deepEqual(result, responseTagged, "returns the decoded tagged response");
+});
+
+test("TauriAppTransport.request converts byte-array map keys to Base64, like the websocket client", async (t) => {
+  const hashKey = fakeHash(7);
+  // { type: "agent_info", value: { <hashKey bytes>: 42 } } as Rust would serialize it.
+  const responseBytes = Uint8Array.from([
+    0x82, // map, 2 entries
+    ...mpStr("type"),
+    ...mpStr("agent_info"),
+    ...mpStr("value"),
+    0x81, // map, 1 entry
+    ...mpBin(hashKey),
+    42, // positive fixint
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke: async () => Array.from(responseBytes),
+    },
+  };
+
+  const transport = new TauriAppTransport("holochain");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: any = await transport.request({
+    type: "agent_info",
+    value: null,
+  });
+
+  t.equal(
+    result.value[encodeHashToBase64(hashKey)],
+    42,
+    "a HoloHash map key is decoded to its Base64 form",
+  );
+});
+
+test("AppWebsocket.connect uses the Tauri transport in a Tauri webview", async (t) => {
+  const agentKey = fakeHash(1);
+  let invokedCmd: string | undefined;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: {
+      INSTALLED_APP_ID: "my-app",
+      PLUGIN_NAME: "holochain",
+    },
+    __TAURI_INTERNALS__: {
+      invoke: async (cmd: string) => {
+        invokedCmd = cmd;
+        return Array.from(
+          encode({
+            type: "app_info",
+            value: {
+              agent_pub_key: agentKey,
+              installed_app_id: "my-app",
+              cell_info: {},
+            },
+          }),
+        );
+      },
+    },
+  };
+
+  const appWs = await AppWebsocket.connect();
+
+  t.ok(
+    appWs.client instanceof TauriAppTransport,
+    "the AppWebsocket is backed by the Tauri transport, not a websocket",
+  );
+  t.equal(
+    appWs.installedAppId,
+    "my-app",
+    "installed app id comes from app_info",
+  );
+  t.equal(
+    encodeHashToBase64(appWs.myPubKey),
+    encodeHashToBase64(agentKey),
+    "agent key comes from app_info",
+  );
+  t.equal(
+    invokedCmd,
+    "plugin:holochain|app_request",
+    "app_info was fetched through the plugin command",
+  );
+});
+
+test("AppWebsocket.callZome signs with the host signer and routes the call over Tauri IPC", async (t) => {
+  let signerCalled = false;
+  let callZomeSeen = false;
+  const zomeResult = ["post-a", "post-b"];
+  const fakeSigned = {
+    bytes: Uint8Array.from([1, 2, 3]),
+    signature: Uint8Array.from([4, 5, 6]),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore-next-line
+  globalThis.window = {
+    __HC_TAURI_HOLOCHAIN__: { INSTALLED_APP_ID: "my-app" },
+    __HC_ZOME_CALL_SIGNER__: {
+      signZomeCall: async () => {
+        signerCalled = true;
+        return fakeSigned;
+      },
+    },
+    __TAURI_INTERNALS__: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invoke: async (_cmd: string, args: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const req: any = decode(Uint8Array.from(args.request));
+        if (req.type === "app_info") {
+          return Array.from(
+            encode({
+              type: "app_info",
+              value: {
+                agent_pub_key: fakeHash(2),
+                installed_app_id: "my-app",
+                cell_info: {},
+              },
+            }),
+          );
+        }
+        if (req.type === "call_zome") {
+          callZomeSeen = true;
+          // ZomeCalled.value is the msgpack-encoded zome output (ExternIO bytes).
+          return Array.from(
+            encode({ type: "call_zome", value: encode(zomeResult) }),
+          );
+        }
+        throw new Error(`unexpected request type ${req.type}`);
+      },
+    },
+  };
+
+  const appWs = await AppWebsocket.connect();
+  const result = await appWs.callZome({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cell_id: [fakeHash(3), fakeHash(2)] as any,
+    zome_name: "posts",
+    fn_name: "get_all_posts",
+    payload: null,
+  });
+
+  t.ok(signerCalled, "the host zome-call signer was used");
+  t.ok(callZomeSeen, "a call_zome request was sent over Tauri IPC");
+  t.deepEqual(result, zomeResult, "the zome response was decoded and returned");
+});


### PR DESCRIPTION
## Summary

Adds a **Tauri IPC transport** for the App API so a UI running inside an in-process Tauri plugin webview can reach a same-process conductor without a loopback websocket. The websocket path is untouched and remains the transport for the separated client + service deployment and any non-Tauri consumer.

When the plugin injects its `__HC_TAURI_HOLOCHAIN__` marker on `window`, `AppWebsocket.connect()` transparently builds a `TauriAppTransport` instead of a `WsClient` — no consumer code change. `callZome`, `appInfo`, signals, clone cells, etc. all work unchanged because the transport is a drop-in for the slice of `WsClient` that `AppWebsocket` uses.

## Design

Same bytes, different pipe: the unit of transfer is the msgpack-encoded tagged `{ type, value }` payload — identical to what the websocket carries — moved through the `plugin:holochain|app_request` command and decoded with the same `Uint8Array`→Base64 map-key converter `WsClient` uses, so HoloHash-keyed maps deserialize identically. No new DTOs, no JSON, no parallel type definitions.

- `src/environments/tauri.ts` — `isTauriHolochain()` detector + injected-env accessor (mirrors `launcher.ts`).
- `src/api/app/tauri-transport.ts` — `TauriAppTransport`: `request()` over IPC + signal bridge re-emitted on Emittery.
- `src/api/app/websocket.ts` — `connect()` branches to the Tauri transport ahead of the launcher-env websocket rewrite; the transport field is relaxed to a minimal `AppClientTransport` interface that `WsClient` already satisfies.
- `test/tauri.ts` — 22 pure unit tests (mocked `invoke`, no conductor) locking in the encode/dispatch/decode contract, signal delivery, and host-signed zome calls. Wired into CI.

## Trust model

The websocket path is scoped by a per-app auth token. The Tauri path replaces that with: (a) the conductor derives the app id from the **calling window's label**, never from a JS-supplied argument, and (b) Tauri's capability/permission system gates the `app_request` command to the intended windows. Zome calls are still signed by the in-process keystore via the host signer — no signing key is exposed to the webview.

## Notes

- Base is `main-0.6` (the Holochain 0.6 / 0.20.x release line).
- Ships **lockstep** with the Rust side in holochain/android-service-runtime#137, which injects the env, dispatches `app_request`, and forwards signals.

## Test plan

- `npm run test:tauri` → 22/22 pass (no conductor required); now runs on every PR via the Test workflow.
- Existing websocket e2e tests unaffected.