### PR TITLE
ci(release): automate npm releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 ### Summary
 
-
 ### TODO:
-- [ ] CHANGELOG mentions all code changes.
+
 - [ ] docs have been updated (`npm run build:docs`)

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,25 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact version to release (e.g. 1.2.3). Leave empty to infer from commits."
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  prepare:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/main-')
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@e9a629cbd174a20a7027edc5afdc615d51089653 # v1.16.0
+    with:
+      cliff_config_url: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
+      force_version: ${{ inputs.version }}
+      install_deps: true
+    secrets:
+      GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,18 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+      - "main-*"
+
+permissions: {}
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+      id-token: write
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@e9a629cbd174a20a7027edc5afdc615d51089653 # v1.16.0
+    with:
+      build_script: build

--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ nix develop
 npm run test
 ```
 
+## Releasing
+
+1. Open the
+   [Prepare Release workflow](https://github.com/holochain/holochain-client-js/actions/workflows/release-prepare.yml)
+   on GitHub Actions, select the `main` branch, and run it. You may provide an
+   exact version or leave the version empty to infer it from the commits since
+   the latest release.
+2. Review the generated release pull request, including the package version and
+   changelog, then merge it into `main`.
+3. The merge publishes `@holochain/client` to npm with provenance and creates
+   the matching Git tag and GitHub release. Prerelease versions are published
+   with the npm `next` tag.
+
 ## Contribute
 
 Holochain is an open source project.  We welcome all sorts of participation and are actively working on increasing surface area to accept it.  Please see our [contribution guidelines](/CONTRIBUTING.md) for our general practices and protocols on participating in the community, as well as specific expectations around things like code formatting, testing practices, continuous integration, etc.


### PR DESCRIPTION
### Summary

Automate npm release preparation and publishing with Holochain reusable workflows. Release pull requests now update the package version and changelog, while merging a labeled release pull request publishes to npm with provenance, creates the Git tag, and creates the GitHub release.

Validation: actionlint, npm ci, npm run build, rebuilt integration fixtures and tests, Markdown checks, and npm pack --dry-run.

Closes #438

### TODO:

- [x] docs have been updated (`npm run build:docs`)